### PR TITLE
Add WithTransactionMaxGasLimit option

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -122,12 +122,13 @@ func GenerateDefaultServiceKey(
 
 // config is a set of configuration options for an emulated blockchain.
 type config struct {
-	ServiceKey         ServiceKey
-	Store              storage.Store
-	SimpleAddresses    bool
-	GenesisTokenSupply cadence.UFix64
-	ScriptGasLimit     uint64
-	TransactionExpiry  uint
+	ServiceKey             ServiceKey
+	Store                  storage.Store
+	SimpleAddresses        bool
+	GenesisTokenSupply     cadence.UFix64
+	TransactionMaxGasLimit uint64
+	ScriptGasLimit         uint64
+	TransactionExpiry      uint
 }
 
 func (conf config) GetStore() storage.Store {
@@ -160,6 +161,7 @@ func (conf config) GetServiceKey() ServiceKey {
 
 const defaultGenesisTokenSupply = "100000000000.0"
 const defaultScriptGasLimit = 100000
+const defaultTransactionMaxGasLimit = flowgo.DefaultMaxGasLimit
 
 // defaultConfig is the default configuration for an emulated blockchain.
 var defaultConfig = func() config {
@@ -169,12 +171,13 @@ var defaultConfig = func() config {
 	}
 
 	return config{
-		ServiceKey:         DefaultServiceKey(),
-		Store:              nil,
-		SimpleAddresses:    false,
-		GenesisTokenSupply: genesisTokenSupply,
-		ScriptGasLimit:     defaultScriptGasLimit,
-		TransactionExpiry:  0, // TODO: replace with sensible default
+		ServiceKey:             DefaultServiceKey(),
+		Store:                  nil,
+		SimpleAddresses:        false,
+		GenesisTokenSupply:     genesisTokenSupply,
+		ScriptGasLimit:         defaultScriptGasLimit,
+		TransactionMaxGasLimit: defaultTransactionMaxGasLimit,
+		TransactionExpiry:      0, // TODO: replace with sensible default
 	}
 }()
 
@@ -217,9 +220,23 @@ func WithGenesisTokenSupply(supply cadence.UFix64) Option {
 	}
 }
 
+// WithTransactionMaxGasLimit sets the maximum gas limit for transactions.
+//
+// Individual transactions will still be bounded by the limit they declare.
+// This function sets the maximum limit that any transaction can declare.
+//
+// This limit does not affect script executions. Use WithScriptGasLimit
+// to set the gas limit for script executions.
+func WithTransactionMaxGasLimit(maxLimit uint64) Option {
+	return func(c *config) {
+		c.TransactionMaxGasLimit = maxLimit
+	}
+}
+
 // WithScriptGasLimit sets the gas limit for scripts.
 //
 // This limit does not affect transactions, which declare their own limit.
+// Use WithTransactionMaxGasLimit to set the maximum gas limit for transactions.
 func WithScriptGasLimit(limit uint64) Option {
 	return func(c *config) {
 		c.ScriptGasLimit = limit
@@ -397,7 +414,7 @@ func configureTransactionValidator(conf config, blocks *blocks) *access.Transact
 			ExpiryBuffer:                 0,
 			AllowEmptyReferenceBlockID:   conf.TransactionExpiry == 0,
 			AllowUnknownReferenceBlockID: false,
-			MaxGasLimit:                  flowgo.DefaultMaxGasLimit,
+			MaxGasLimit:                  conf.TransactionMaxGasLimit,
 			CheckScriptsParse:            true,
 			MaxTxSizeLimit:               flowgo.DefaultMaxTxSizeLimit,
 		},

--- a/cmd/emulator/start/start.go
+++ b/cmd/emulator/start/start.go
@@ -36,22 +36,23 @@ import (
 )
 
 type Config struct {
-	Port               int           `default:"3569" flag:"port,p" info:"port to run RPC server"`
-	HTTPPort           int           `default:"8080" flag:"http-port" info:"port to run HTTP server"`
-	Verbose            bool          `default:"false" flag:"verbose,v" info:"enable verbose logging"`
-	BlockTime          time.Duration `flag:"block-time,b" info:"time between sealed blocks, e.g. '300ms', '-1.5h' or '2h45m'. Valid units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'"`
-	ServicePrivateKey  string        `flag:"service-priv-key" info:"service account private key"`
-	ServicePublicKey   string        `flag:"service-pub-key" info:"service account public key"`
-	ServiceKeySigAlgo  string        `flag:"service-sig-algo" info:"service account key signature algorithm"`
-	ServiceKeyHashAlgo string        `flag:"service-hash-algo" info:"service account key hash algorithm"`
-	Init               bool          `default:"false" flag:"init" info:"whether to initialize a new account profile"`
-	GRPCDebug          bool          `default:"false" flag:"grpc-debug" info:"enable gRPC server reflection for debugging with grpc_cli"`
-	Persist            bool          `default:"false" flag:"persist" info:"enable persistent storage"`
-	DBPath             string        `default:"./flowdb" flag:"dbpath" info:"path to database directory"`
-	SimpleAddresses    bool          `default:"false" flag:"simple-addresses" info:"use sequential addresses starting with 0x01"`
-	TokenSupply        string        `default:"100000000000.0" flag:"token-supply" info:"initial FLOW token supply"`
-	ScriptGasLimit     int           `default:"100000" flag:"script-gas-limit" info:"gas limit for scripts"`
-	TransactionExpiry  int           `default:"10" flag:"transaction-expiry" info:"transaction expiry, measured in blocks"`
+	Port                   int           `default:"3569" flag:"port,p" info:"port to run RPC server"`
+	HTTPPort               int           `default:"8080" flag:"http-port" info:"port to run HTTP server"`
+	Verbose                bool          `default:"false" flag:"verbose,v" info:"enable verbose logging"`
+	BlockTime              time.Duration `flag:"block-time,b" info:"time between sealed blocks, e.g. '300ms', '-1.5h' or '2h45m'. Valid units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'"`
+	ServicePrivateKey      string        `flag:"service-priv-key" info:"service account private key"`
+	ServicePublicKey       string        `flag:"service-pub-key" info:"service account public key"`
+	ServiceKeySigAlgo      string        `flag:"service-sig-algo" info:"service account key signature algorithm"`
+	ServiceKeyHashAlgo     string        `flag:"service-hash-algo" info:"service account key hash algorithm"`
+	Init                   bool          `default:"false" flag:"init" info:"whether to initialize a new account profile"`
+	GRPCDebug              bool          `default:"false" flag:"grpc-debug" info:"enable gRPC server reflection for debugging with grpc_cli"`
+	Persist                bool          `default:"false" flag:"persist" info:"enable persistent storage"`
+	DBPath                 string        `default:"./flowdb" flag:"dbpath" info:"path to database directory"`
+	SimpleAddresses        bool          `default:"false" flag:"simple-addresses" info:"use sequential addresses starting with 0x01"`
+	TokenSupply            string        `default:"100000000000.0" flag:"token-supply" info:"initial FLOW token supply"`
+	TransactionExpiry      int           `default:"10" flag:"transaction-expiry" info:"transaction expiry, measured in blocks"`
+	TransactionMaxGasLimit int           `default:"9999" flag:"transaction-max-gas-limit" info:"maximum gas limit for transactions"`
+	ScriptGasLimit         int           `default:"100000" flag:"script-gas-limit" info:"gas limit for scripts"`
 }
 
 const EnvPrefix = "FLOW"
@@ -131,16 +132,17 @@ func Cmd(getServiceKey serviceKeyFunc) *cobra.Command {
 				GRPCDebug: conf.GRPCDebug,
 				HTTPPort:  conf.HTTPPort,
 				// TODO: allow headers to be parsed from environment
-				HTTPHeaders:        nil,
-				BlockTime:          conf.BlockTime,
-				ServicePublicKey:   servicePublicKey,
-				ServiceKeySigAlgo:  serviceKeySigAlgo,
-				ServiceKeyHashAlgo: serviceKeyHashAlgo,
-				Persist:            conf.Persist,
-				DBPath:             conf.DBPath,
-				GenesisTokenSupply: parseTokenSupply(conf.TokenSupply),
-				ScriptGasLimit:     uint64(conf.ScriptGasLimit),
-				TransactionExpiry:  uint(conf.TransactionExpiry),
+				HTTPHeaders:            nil,
+				BlockTime:              conf.BlockTime,
+				ServicePublicKey:       servicePublicKey,
+				ServiceKeySigAlgo:      serviceKeySigAlgo,
+				ServiceKeyHashAlgo:     serviceKeyHashAlgo,
+				Persist:                conf.Persist,
+				DBPath:                 conf.DBPath,
+				GenesisTokenSupply:     parseTokenSupply(conf.TokenSupply),
+				TransactionMaxGasLimit: uint64(conf.TransactionMaxGasLimit),
+				ScriptGasLimit:         uint64(conf.ScriptGasLimit),
+				TransactionExpiry:      uint(conf.TransactionExpiry),
 			}
 
 			emu := server.NewEmulatorServer(logger, serverConf)

--- a/server/server.go
+++ b/server/server.go
@@ -73,18 +73,19 @@ var (
 
 // Config is the configuration for an emulator server.
 type Config struct {
-	GRPCPort           int
-	GRPCDebug          bool
-	HTTPPort           int
-	HTTPHeaders        []HTTPHeader
-	BlockTime          time.Duration
-	ServicePublicKey   crypto.PublicKey
-	ServiceKeySigAlgo  crypto.SignatureAlgorithm
-	ServiceKeyHashAlgo crypto.HashAlgorithm
-	GenesisTokenSupply cadence.UFix64
-	TransactionExpiry  uint
-	ScriptGasLimit     uint64
-	Persist            bool
+	GRPCPort               int
+	GRPCDebug              bool
+	HTTPPort               int
+	HTTPHeaders            []HTTPHeader
+	BlockTime              time.Duration
+	ServicePublicKey       crypto.PublicKey
+	ServiceKeySigAlgo      crypto.SignatureAlgorithm
+	ServiceKeyHashAlgo     crypto.HashAlgorithm
+	GenesisTokenSupply     cadence.UFix64
+	TransactionExpiry      uint
+	TransactionMaxGasLimit uint64
+	ScriptGasLimit         uint64
+	Persist                bool
 	// DBPath is the path to the Badger database on disk.
 	DBPath string
 	// DBGCInterval is the time interval at which to garbage collect the Badger value log.
@@ -191,6 +192,7 @@ func configureBlockchain(conf *Config, store storage.Store) (*emulator.Blockchai
 	options := []emulator.Option{
 		emulator.WithStore(store),
 		emulator.WithGenesisTokenSupply(conf.GenesisTokenSupply),
+		emulator.WithTransactionMaxGasLimit(conf.TransactionMaxGasLimit),
 		emulator.WithScriptGasLimit(conf.ScriptGasLimit),
 		emulator.WithTransactionExpiry(conf.TransactionExpiry),
 	}


### PR DESCRIPTION
⚠️ This PR was opened to unblock @joshuahannan, it will be WIP until I finish adding tests.

## Description

This PR adds the `emulator.WithTransactionMaxGasLimit` option, which can be used to configure a custom maximum for transaction gas limits. 

This is intended as an advanced feature for users who wish to tune the gas consumption of their transactions and contracts.