### PR TITLE
[Don't merge yet] Update fvm context to set logging one by default

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -286,6 +286,7 @@ func configureFVM(conf config, blocks *blocks) (*fvm.VirtualMachine, fvm.Context
 		fvm.WithRestrictedDeployment(false),
 		fvm.WithRestrictedAccountCreation(false),
 		fvm.WithGasLimit(conf.ScriptGasLimit),
+		fvm.WithCadenceLogging(true),
 	)
 
 	return vm, ctx, nil


### PR DESCRIPTION
## Description
[This FVM PR ](https://github.com/onflow/flow-go/pull/128) disables cadence logging by default. This PR will set the flag for cadence logging to keep the functionality as before 

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
