### PR TITLE
Use new GitHub Actions Docker actions to build and push images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test:
+    name: "Test"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -27,6 +28,7 @@ jobs:
     - run: make ci
 
   lint:
+    name: "Lint"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -38,29 +40,59 @@ jobs:
           args: --timeout=10m
 
   docker:
-    needs: test
-    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
+    needs: test
+    name: "Docker image"
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - uses: actions/setup-go@v1
-      with:
-        go-version: '1.14.5'
-    - uses: actions/cache@v1
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Build the Docker image
-      run: make docker-build
-    - name: Login to GCR
-      uses: docker/login-action@v1
-      with:
-        registry: gcr.io
-        username: _json_key
-        password: ${{ secrets.GCR_JSON_KEY }}
-    - name: Push the Docker image to GCR
-      run: make docker-push
+
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=gcr.io/dl-flow/emulator
+          VERSION=edge
+
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          fi
+
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:latest"
+          fi
+
+          echo ::set-output name=tags::${TAGS}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to GCR
+        uses: docker/login-action@v1
+        with:
+          registry: gcr.io
+          username: _json_key
+          password: ${{ secrets.GCR_JSON_KEY }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
+          context: .
+          file: ./cmd/emulator/Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 # The short Git commit hash
 SHORT_COMMIT := $(shell git rev-parse --short HEAD)
-# The tag of the current commit, otherwise empty
-VERSION := $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
 # Name of the cover profile
 COVER_PROFILE := cover.out
 # Disable go sum database lookup for private repos
@@ -54,21 +52,6 @@ generate-mocks:
 
 .PHONY: ci
 ci: install-tools test check-tidy test coverage check-headers
-
-.PHONY: docker-build-emulator
-docker-build:
-	docker build --ssh default -f cmd/emulator/Dockerfile -t gcr.io/dl-flow/emulator:latest -t "gcr.io/dl-flow/emulator:$(SHORT_COMMIT)" .
-ifneq (${VERSION},)
-	docker tag gcr.io/dl-flow/emulator:latest gcr.io/dl-flow/emulator:${VERSION}
-endif
-
-.PHONY: docker-push-emulator
-docker-push:
-	docker push gcr.io/dl-flow/emulator:latest
-	docker push "gcr.io/dl-flow/emulator:$(SHORT_COMMIT)"
-ifneq (${VERSION},)
-	docker push "gcr.io/dl-flow/emulator:${VERSION}"
-endif
 
 .PHONY: install-linter
 install-linter:


### PR DESCRIPTION
## Description

Building Docker images is currently not working on GitHub Actions.

Use the opportunity to fix this by switching to the latest and greatest GitHub Actions dedicated to efficiently building and pushing Docker images.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
