### PR TITLE
fixed FLOW CLI links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ with the real network API.
 
 ## Running the emulator with the Flow CLI
 
-The emulator is bundled with the [Flow CLI](https://github.com/dapperlabs/flow-cli), a command-line interface for working with Flow.
+The emulator is bundled with the [Flow CLI](https://docs.onflow.org/flow-cli), a command-line interface for working with Flow.
 
 ### Installation
 
-Follow [these steps](https://github.com/dapperlabs/flow-cli#flow-cli) to install the Flow CLI.
+Follow [these steps](https://github.com/onflow/flow-cli) to install the Flow CLI.
 
 ### Starting the server
 


### PR DESCRIPTION
flow cli links pointed to dapperlabs github resulting in a 404 error.
Just changed the FLOW CLI link to the offical flow website (it could be usefull when it will have a richer description) and the installation steps to the github 

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels