### PR TITLE
Update to Cadence v0.13.5 and Flow Go v0.14.8

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -418,7 +418,8 @@ func bootstrapLedger(
 
 	bootstrap := configureBootstrapProcedure(conf, flowAccountKey, conf.GenesisTokenSupply)
 
-	err := vm.Run(ctx, bootstrap, ledger)
+	programs := fvm.NewEmptyPrograms()
+	err := vm.Run(ctx, bootstrap, ledger, programs)
 	if err != nil {
 		return err
 	}
@@ -658,7 +659,8 @@ func (b *Blockchain) getAccount(address flowgo.Address) (*flowgo.Account, error)
 
 	view := b.storage.LedgerViewByHeight(latestBlock.Header.Height)
 
-	account, err := b.vm.GetAccount(b.vmCtx, address, view)
+	programs := fvm.NewEmptyPrograms()
+	account, err := b.vm.GetAccount(b.vmCtx, address, view, programs)
 	if errors.Is(err, fvm.ErrAccountNotFound) {
 		return nil, &AccountNotFoundError{Address: address}
 	}
@@ -803,7 +805,9 @@ func (b *Blockchain) executeNextTransaction(ctx fvm.Context) (*types.Transaction
 		) (*fvm.TransactionProcedure, error) {
 			tx := fvm.Transaction(txBody, txIndex)
 
-			err := b.vm.Run(ctx, tx, ledgerView)
+			programs := fvm.NewEmptyPrograms()
+
+			err := b.vm.Run(ctx, tx, ledgerView, programs)
 			if err != nil {
 				return nil, err
 			}
@@ -950,7 +954,8 @@ func (b *Blockchain) ExecuteScriptAtBlock(script []byte, arguments [][]byte, blo
 
 	scriptProc := fvm.Script(script).WithArguments(arguments...)
 
-	err = b.vm.Run(blockContext, scriptProc, requestedLedgerView)
+	programs := fvm.NewEmptyPrograms()
+	err = b.vm.Run(blockContext, scriptProc, requestedLedgerView, programs)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/improbable-eng/grpc-web v0.12.0
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381
-	github.com/onflow/cadence v0.13.0
-	github.com/onflow/flow-go v0.14.1-0.20210223171959-f21d550c6ab0
+	github.com/onflow/cadence v0.13.5
+	github.com/onflow/flow-go v0.14.8
 	github.com/onflow/flow-go-sdk v0.15.0
 	github.com/onflow/flow-go/crypto v0.12.0
 	github.com/onflow/flow/protobuf/go/flow v0.1.9

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/onflow/flow-emulator
 go 1.13
 
 require (
-	github.com/davecgh/go-spew v1.1.1
 	github.com/dgraph-io/badger/v2 v2.0.3
 	github.com/fxamacker/cbor/v2 v2.2.1-0.20201006223149-25f67fca9803
 	github.com/golang/mock v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -184,7 +184,6 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/ef-ds/deque v1.0.4/go.mod h1:gXDnTC3yqvBcHbq2lcExjtAcVrOnJCbMcZXmuj8Z4tg=
 github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyCIo22xvs=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -319,6 +318,8 @@ github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
+github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2 v2.0.0-rc.2/go.mod h1:BL7w7qd2l/j9jgY6WMhYutfOFQc0I8RTVwtjpnAMoTM=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-20200501113911-9a95f0fdbfea/go.mod h1:GugMBs30ZSAkckqXEAIEGyYdDH6EgqowG8ppA3Zt+AY=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -765,12 +766,14 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.13.0 h1:rMQpIwbZyqdiKV3f8nwxmyqyJahHcDRHDaZcjNH3sfI=
 github.com/onflow/cadence v0.13.0/go.mod h1:VuW4hf5AuC/PkxKD6akqq03Fgk0CpOM3ZOR6n7htNIw=
+github.com/onflow/cadence v0.13.5 h1:R8myLyT4E3DU0q1A3NRnvwepvVHQniruDd0ncNejsUw=
+github.com/onflow/cadence v0.13.5/go.mod h1:EEXKRNuW5C2E1wRM4fLhfqoTgXohPFieXwOGJubz1Jg=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1 h1:nmIDPf94F9Ecx6ecGyd4uYBUl4LluntWLvtwAJYt4tw=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1/go.mod h1:4zE/4A+5zyahxSFccQmcBqzp4ONXIwvGHaOKN8h8CRM=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0 h1:M1I4z027GHOLcjkj9lL2UUUpZpEAF90hY5gRqvFGAPg=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0/go.mod h1:1zoTjp1KzNnOPkyqKmWKerUyf0gciw+e6tAEt0Ks3JE=
-github.com/onflow/flow-go v0.14.1-0.20210223171959-f21d550c6ab0 h1:m9nJozAZGkpBnUPZl4boiyQ1C7wRxean0Fs6rEcrwzY=
-github.com/onflow/flow-go v0.14.1-0.20210223171959-f21d550c6ab0/go.mod h1:7FMn+uagtcvn/wTEZEzAtjXKma8F3kkLQbq1dueDfow=
+github.com/onflow/flow-go v0.14.8 h1:zCVJxZS4tsRYzgr/PkBSDfkeN1LT7uJDH9C3Q6TlwtI=
+github.com/onflow/flow-go v0.14.8/go.mod h1:fnFH5+U15gs7xQ8AVxDLwLOzgdujFnAX7ULYxKe5+9I=
 github.com/onflow/flow-go-sdk v0.15.0 h1:h2FD/d1p/VRIWEcAYcVOT2rm4qKppIn4sVog+/eXKrw=
 github.com/onflow/flow-go-sdk v0.15.0/go.mod h1:Dkcd1xQta8EPQL5XKE9vi2OTa6CoMsbX0jIQ4ozhUUs=
 github.com/onflow/flow-go/crypto v0.12.0 h1:TMsqn5nsW4vrCIFG/HRE/oy/a5/sffHrDRDYqicwO98=

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
@@ -198,7 +197,6 @@ func TestSubmitTransaction_Invalid(t *testing.T) {
 
 		result, err := b.ExecuteNextTransaction()
 		require.NoError(t, err)
-		spew.Dump(result)
 
 		require.Error(t, result.Error)
 


### PR DESCRIPTION
Work towards dapperlabs/flow-go#5372

## Description

- Update to Cadence v0.13.5. Release notes:
  - [v0.13.1](https://github.com/onflow/cadence/releases/tag/v0.13.1)
  - [v0.13.2](https://github.com/onflow/cadence/releases/tag/v0.13.2)
  - [v0.13.3](https://github.com/onflow/cadence/releases/tag/v0.13.3)
  - [v0.13.4](https://github.com/onflow/cadence/releases/tag/v0.13.4)
  - [v0.13.5](https://github.com/onflow/cadence/releases/tag/v0.13.5)

- Update to [Flow Go v0.14.8](https://github.com/onflow/flow-go/releases/tag/v0.14.8) 
______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-go-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
