### PR TITLE
Add block view

### DIFF
--- a/block_info_test.go
+++ b/block_info_test.go
@@ -69,7 +69,7 @@ func TestBlockInfo(t *testing.T) {
 
 		require.Len(t, result.Logs, 2)
 		assert.Equal(t, fmt.Sprintf("Block(height: %v, view: %v, id: 0x%x, timestamp: %.8f)", block2.Header.Height+1,
-			block2.Header.View, b.PendingBlockID(), float64(b.PendingBlockTimestamp().Unix())), result.Logs[0])
+			b.PendingBlockView(), b.PendingBlockID(), float64(b.PendingBlockTimestamp().Unix())), result.Logs[0])
 		assert.Equal(t, fmt.Sprintf("Block(height: %v, view: %v, id: 0x%x, timestamp: %.8f)", block2.Header.Height,
 			block2.Header.View, block2.ID(), float64(block2.Header.Timestamp.Unix())), result.Logs[1])
 	})

--- a/block_test.go
+++ b/block_test.go
@@ -99,8 +99,11 @@ func TestCommitBlock(t *testing.T) {
 }
 
 func TestBlockView(t *testing.T) {
+	const nBlocks = 3
+
 	b, err := emulator.NewBlockchain()
 	require.NoError(t, err)
+
 
 	t.Run("genesis should have 0 view", func(t *testing.T) {
 		block, err := b.GetBlockByHeight(0)
@@ -112,7 +115,7 @@ func TestBlockView(t *testing.T) {
 	addTwoScript, _ := deployAndGenerateAddTwoScript(t, b)
 
 	// create a few blocks, each with one transaction
-	for i := 0; i < 3; i++ {
+	for i := 0; i < nBlocks; i++ {
 
 		tx := flow.NewTransaction().
 			SetScript([]byte(addTwoScript)).
@@ -131,14 +134,10 @@ func TestBlockView(t *testing.T) {
 		// execute and commit the block
 		_, _, err = b.ExecuteAndCommitBlock()
 		require.NoError(t, err)
-
 	}
 
-	for height := uint64(1); ; height++ {
+	for height := uint64(1); height <= nBlocks+1; height++ {
 		block, err := b.GetBlockByHeight(height)
-		if _, ok := err.(emulator.BlockNotFoundError); ok {
-			break
-		}
 		require.NoError(t, err)
 
 		maxView := height*emulator.MaxViewIncrease

--- a/block_test.go
+++ b/block_test.go
@@ -19,6 +19,7 @@
 package emulator_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/onflow/flow-go-sdk"
@@ -95,4 +96,55 @@ func TestCommitBlock(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, flow.TransactionStatusSealed, tx2Result.Status)
 	assert.Error(t, tx2Result.Error)
+}
+
+func TestBlockView(t *testing.T) {
+	b, err := emulator.NewBlockchain()
+	require.NoError(t, err)
+
+	t.Run("genesis should have 0 view", func(t *testing.T) {
+		block, err := b.GetBlockByHeight(0)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(0), block.Header.Height)
+		assert.Equal(t, uint64(0), block.Header.View)
+	})
+
+	addTwoScript, _ := deployAndGenerateAddTwoScript(t, b)
+
+	// create a few blocks, each with one transaction
+	for i := 0; i < 3; i++ {
+
+		tx := flow.NewTransaction().
+			SetScript([]byte(addTwoScript)).
+			SetGasLimit(flowgo.DefaultMaxGasLimit).
+			SetProposalKey(b.ServiceKey().Address, b.ServiceKey().Index, b.ServiceKey().SequenceNumber).
+			SetPayer(b.ServiceKey().Address).
+			AddAuthorizer(b.ServiceKey().Address)
+
+		err = tx.SignEnvelope(b.ServiceKey().Address, b.ServiceKey().Index, b.ServiceKey().Signer())
+		assert.NoError(t, err)
+
+		// Add tx to pending block
+		err = b.AddTransaction(*tx)
+		assert.NoError(t, err)
+
+		// execute and commit the block
+		_, _, err = b.ExecuteAndCommitBlock()
+		require.NoError(t, err)
+
+	}
+
+	for height := uint64(1); ; height++ {
+		block, err := b.GetBlockByHeight(height)
+		if _, ok := err.(emulator.BlockNotFoundError); ok {
+			break
+		}
+		require.NoError(t, err)
+
+		maxView := height*emulator.MaxViewIncrease
+		t.Run(fmt.Sprintf("block %d should have view <%d", height, maxView), func(t *testing.T) {
+			assert.Equal(t, height, block.Header.Height)
+			assert.LessOrEqual(t, block.Header.View, maxView)
+		})
+	}
 }

--- a/blockchain.go
+++ b/blockchain.go
@@ -495,6 +495,11 @@ func (b *Blockchain) PendingBlockID() flowgo.Identifier {
 	return b.pendingBlock.ID()
 }
 
+// PendingBlockView returns the view of the pending block.
+func (b *Blockchain) PendingBlockView() uint64 {
+	return b.pendingBlock.view
+}
+
 // PendingBlockTimestamp returns the Timestamp of the pending block.
 func (b *Blockchain) PendingBlockTimestamp() time.Time {
 	return b.pendingBlock.Block().Header.Timestamp


### PR DESCRIPTION
Closes: https://github.com/dapperlabs/flow-go/issues/5454

## Description

This PR sets the block view field on blocks produced by the emulator. To mimic the non-consecutive behaviour of views in a live network, the view is increased by between 1 and 3 for each new block.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
