### PR TITLE
Fix typo of 'tolerance'

### DIFF
--- a/server/liveness/check.go
+++ b/server/liveness/check.go
@@ -46,7 +46,7 @@ func (c *internalCheck) CheckIn() {
 	c.lock.Unlock()
 }
 
-// IsLive checks if we are still live against the given the tolerace between hearbeats.
+// IsLive checks if we are still live against the given the tolerance between hearbeats.
 //
 // If tolerance is 0, the default tolerance is used.
 func (c *internalCheck) IsLive(tolerance time.Duration) bool {

--- a/server/liveness/collector.go
+++ b/server/liveness/collector.go
@@ -82,7 +82,7 @@ func (c *CheckCollector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if toleranceStr := r.Header.Get(ToleranceHeader); toleranceStr != "" {
 		tolerance, err = time.ParseDuration(toleranceStr)
 		if err != nil {
-			http.Error(w, "Invalid tolerace: "+toleranceStr, http.StatusBadRequest)
+			http.Error(w, "Invalid tolerance: "+toleranceStr, http.StatusBadRequest)
 			return
 		}
 	}
@@ -95,7 +95,7 @@ func (c *CheckCollector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// IsLive checks if we are still live against the given the tolerace between hearbeats.
+// IsLive checks if we are still live against the given the tolerance between hearbeats.
 //
 // If tolerance is 0, the default tolerance is used.
 func (c *CheckCollector) IsLive(tolerance time.Duration) bool {


### PR DESCRIPTION
## Description

Just spotted a typo and fixed it

______

For contributor use:

- [x] Targeted PR against `master` branch
- [N/A] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [N/A] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [no permission] Added appropriate labels
