### PR TITLE
nil values should be persisted to memstore

### DIFF
--- a/storage/memstore/memstore.go
+++ b/storage/memstore/memstore.go
@@ -276,11 +276,9 @@ func (s *Store) insertLedgerDelta(blockHeight uint64, delta delta.Delta) error {
 	ids, values := delta.RegisterUpdates()
 	for i, value := range values {
 		key := ids[i]
-		if value != nil {
-			err := newLedger.Set(key.Owner, key.Controller, key.Key, value)
-			if err != nil {
-				return err
-			}
+		err := newLedger.Set(key.Owner, key.Controller, key.Key, value)
+		if err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/onflow/flow-emulator/issues/46

## Description

In bug report https://github.com/onflow/flow-emulator/issues/46 removing a capability was not persisted. This was because changing a register to nil would not be persisted to the memstore due t the check that was fixed in this PR.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
