### PR TITLE
Add tests for infinite loops in scripts and transactions

### DIFF
--- a/script_test.go
+++ b/script_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
+	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/flow-go-sdk"
 	flowgo "github.com/onflow/flow-go/model/flow"
 	"github.com/stretchr/testify/assert"
@@ -107,4 +108,28 @@ func TestExecuteScript_WithArguments(t *testing.T) {
 func TestExecuteScriptAtBlockHeight(t *testing.T) {
 	// TODO
 	// Test that scripts can be executed at different block heights
+}
+
+func TestInfiniteScript(t *testing.T) {
+
+	const limit = 10
+	b, err := emulator.NewBlockchain(
+		emulator.WithScriptGasLimit(limit),
+	)
+	require.NoError(t, err)
+
+	const code = `
+      pub fun main() {
+          main()
+      }
+    `
+	result, err := b.ExecuteScript([]byte(code), nil)
+	require.NoError(t, err)
+
+	require.ErrorAs(t,
+		result.Error,
+		&runtime.ComputationLimitExceededError{
+			Limit: limit,
+		},
+	)
 }

--- a/types/error.go
+++ b/types/error.go
@@ -29,3 +29,7 @@ type FlowError struct {
 func (f *FlowError) Error() string {
 	return f.FlowError.Error()
 }
+
+func (f *FlowError) Unwrap() error {
+	return f.FlowError
+}


### PR DESCRIPTION
## Description

Add tests that ensure that infinitely long running scripts and transactions are properly aborted when they reach the computation limit.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
