### PR TITLE
Upgrade flow-go and fix `--transaction-fees` flag

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -327,6 +327,7 @@ func configureFVM(conf config, blocks *blocks) (*fvm.VirtualMachine, fvm.Context
 		fvm.WithGasLimit(conf.ScriptGasLimit),
 		fvm.WithCadenceLogging(true),
 		fvm.WithAccountStorageLimit(conf.StorageLimitEnabled),
+		fvm.WithTransactionFeesEnabled(conf.TransactionFeesEnabled),
 	)
 
 	return vm, ctx, nil

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.12.0
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381
 	github.com/onflow/cadence v0.16.0
-	github.com/onflow/flow-go v0.17.2-0.20210519201123-f0e3bc9dd03e
+	github.com/onflow/flow-go v0.17.2
 	github.com/onflow/flow-go-sdk v0.20.0-alpha.1
 	github.com/onflow/flow-go/crypto v0.12.0
 	github.com/onflow/flow/protobuf/go/flow v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.12.0
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381
 	github.com/onflow/cadence v0.16.0
-	github.com/onflow/flow-go v0.17.1
+	github.com/onflow/flow-go v0.17.2-0.20210519201123-f0e3bc9dd03e
 	github.com/onflow/flow-go-sdk v0.20.0-alpha.1
 	github.com/onflow/flow-go/crypto v0.12.0
 	github.com/onflow/flow/protobuf/go/flow v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,7 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/ef-ds/deque v1.0.4 h1:iFAZNmveMT9WERAkqLJ+oaABF9AcVQ5AjXem/hroniI=
 github.com/ef-ds/deque v1.0.4/go.mod h1:gXDnTC3yqvBcHbq2lcExjtAcVrOnJCbMcZXmuj8Z4tg=
 github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyCIo22xvs=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
@@ -712,8 +713,8 @@ github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.2 h1:6+zfvSv03ROULuq
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.2/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4zbY76O0Y28QB0766A=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0/go.mod h1:1zoTjp1KzNnOPkyqKmWKerUyf0gciw+e6tAEt0Ks3JE=
-github.com/onflow/flow-go v0.17.1 h1:bPA1lncwdhF+VEFgZ3wOvGa2rKgibqmYwq5tDy6Kz+4=
-github.com/onflow/flow-go v0.17.1/go.mod h1:j8zCo01+2pJL00qpOnwdOqU7spTgOLHFRUp9gsamyNA=
+github.com/onflow/flow-go v0.17.2-0.20210519201123-f0e3bc9dd03e h1:iFBoULDyGfawSX6KDFYGKcSMIxfFPzBZhLOyqTZerqE=
+github.com/onflow/flow-go v0.17.2-0.20210519201123-f0e3bc9dd03e/go.mod h1:j8zCo01+2pJL00qpOnwdOqU7spTgOLHFRUp9gsamyNA=
 github.com/onflow/flow-go-sdk v0.20.0-alpha.1 h1:zy5viTpSQsfKgaoj9PgDOhoklLkG0Fze4okGFZ21Mus=
 github.com/onflow/flow-go-sdk v0.20.0-alpha.1/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4JPdtvJoae1spIUBOFxA8=
 github.com/onflow/flow-go/crypto v0.12.0 h1:TMsqn5nsW4vrCIFG/HRE/oy/a5/sffHrDRDYqicwO98=

--- a/go.sum
+++ b/go.sum
@@ -713,8 +713,8 @@ github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.2 h1:6+zfvSv03ROULuq
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.2/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4zbY76O0Y28QB0766A=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0/go.mod h1:1zoTjp1KzNnOPkyqKmWKerUyf0gciw+e6tAEt0Ks3JE=
-github.com/onflow/flow-go v0.17.2-0.20210519201123-f0e3bc9dd03e h1:iFBoULDyGfawSX6KDFYGKcSMIxfFPzBZhLOyqTZerqE=
-github.com/onflow/flow-go v0.17.2-0.20210519201123-f0e3bc9dd03e/go.mod h1:j8zCo01+2pJL00qpOnwdOqU7spTgOLHFRUp9gsamyNA=
+github.com/onflow/flow-go v0.17.2 h1:tZEM49nWAjH2Eq6Sys6Q1YjRIb8FREBjxYxPJX5svS4=
+github.com/onflow/flow-go v0.17.2/go.mod h1:j8zCo01+2pJL00qpOnwdOqU7spTgOLHFRUp9gsamyNA=
 github.com/onflow/flow-go-sdk v0.20.0-alpha.1 h1:zy5viTpSQsfKgaoj9PgDOhoklLkG0Fze4okGFZ21Mus=
 github.com/onflow/flow-go-sdk v0.20.0-alpha.1/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4JPdtvJoae1spIUBOFxA8=
 github.com/onflow/flow-go/crypto v0.12.0 h1:TMsqn5nsW4vrCIFG/HRE/oy/a5/sffHrDRDYqicwO98=


### PR DESCRIPTION
## Description

A previous version of `flow-go` had a bug when transaction fees were enabled, and also introduce a flag that must be set to enable transaction fees.

This means the emulator still worked, but the `--transaction-fees` didn't work anymore. 

This PR switches flow-go to a version where that is fixed and the  `WithTransactionFeesEnabled` is properly set

:exclamation: `flow-go` version should be switched to a tagged version before this is merged.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
