### PR TITLE
Return error if script fails

### DIFF
--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -549,6 +549,10 @@ func (b *Backend) executeScriptAtBlock(script []byte, arguments [][]byte, blockH
 
 	printScriptResult(b.logger, result)
 
+	if !result.Succeeded() {
+		return nil, result.Error
+	}
+
 	valueBytes, err := jsoncdc.Encode(result.Value)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())


### PR DESCRIPTION
When a script execution fails error should be returned to the client, this is consistent with mainnet and also allows the developer to see what the error was in the client.

Error currently returned was an error of the cadence parser and did not provide any value or information to the client.