### PR TITLE
Expose storage parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This command has several useful flags:
 - `--persist` Enable persistent storage (uses [Badger](https://github.com/dgraph-io/badger) key-value DB)
 - `--dbpath` Path to store database (default: `"./flowdb"`)
 - `--storage-limit` Enable limiting account storage use to their storage capacity
+- `--storage-per-flow` The MB amount of storage capacity an account has per 1 FLOW token it has. e.g. '100.0'. The default is taken from the current version of flow-go
+- `--min-account-balance"` The minimum account balance of an account. This is also the cost of creating one account. e.g. '0.001'. The default is taken from the current version of flow-go
 - `--transaction-fees` Enable transaction fees
 
 ### Using the emulator in a project

--- a/cmd/emulator/start/start.go
+++ b/cmd/emulator/start/start.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onflow/cadence"
 	sdk "github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
+	"github.com/onflow/flow-go/fvm"
 	"github.com/prometheus/common/log"
 	"github.com/psiemens/sconfig"
 	"github.com/sirupsen/logrus"
@@ -49,9 +50,11 @@ type Config struct {
 	Persist                bool          `default:"false" flag:"persist" info:"enable persistent storage"`
 	DBPath                 string        `default:"./flowdb" flag:"dbpath" info:"path to database directory"`
 	SimpleAddresses        bool          `default:"false" flag:"simple-addresses" info:"use sequential addresses starting with 0x01"`
-	TokenSupply            string        `default:"10000000000.0" flag:"token-supply" info:"initial FLOW token supply"`
+	TokenSupply            string        `default:"1000000000.0" flag:"token-supply" info:"initial FLOW token supply"`
 	TransactionExpiry      int           `default:"10" flag:"transaction-expiry" info:"transaction expiry, measured in blocks"`
 	StorageLimitEnabled    bool          `default:"true" flag:"storage-limit" info:"enable account storage limit"`
+	StorageMBPerFLOW       string        `flag:"storage-cost" info:"the MB amount of storage capacity an account has per 1 FLOW token it has. e.g. '100.0'. The default is taken from the current version of flow-go"`
+	MinimumAccountBalance  string        `flag:"min-account-balance" info:"The minimum account balance of an account. This is also the cost of creating one account. e.g. '0.001'. The default is taken from the current version of flow-go"`
 	TransactionFeesEnabled bool          `default:"false" flag:"transaction-fees" info:"enable transaction fees"`
 	TransactionMaxGasLimit int           `default:"9999" flag:"transaction-max-gas-limit" info:"maximum gas limit for transactions"`
 	ScriptGasLimit         int           `default:"100000" flag:"script-gas-limit" info:"gas limit for scripts"`
@@ -129,24 +132,36 @@ func Cmd(getServiceKey serviceKeyFunc) *cobra.Command {
 
 			logger.WithFields(serviceFields).Infof("⚙️   Using service account 0x%s", serviceAddress.Hex())
 
+			minimumStorageReservation := fvm.DefaultMinimumStorageReservation
+			if conf.MinimumAccountBalance != "" {
+				minimumStorageReservation = parseCadenceUFix64(conf.MinimumAccountBalance, "min-account-balance")
+			}
+
+			storageMBPerFLOW := fvm.DefaultStorageMBPerFLOW
+			if conf.StorageMBPerFLOW != "" {
+				storageMBPerFLOW = parseCadenceUFix64(conf.StorageMBPerFLOW, "storage-cost")
+			}
+
 			serverConf := &server.Config{
 				GRPCPort:  conf.Port,
 				GRPCDebug: conf.GRPCDebug,
 				HTTPPort:  conf.HTTPPort,
 				// TODO: allow headers to be parsed from environment
-				HTTPHeaders:            nil,
-				BlockTime:              conf.BlockTime,
-				ServicePublicKey:       servicePublicKey,
-				ServiceKeySigAlgo:      serviceKeySigAlgo,
-				ServiceKeyHashAlgo:     serviceKeyHashAlgo,
-				Persist:                conf.Persist,
-				DBPath:                 conf.DBPath,
-				GenesisTokenSupply:     parseTokenSupply(conf.TokenSupply),
-				TransactionMaxGasLimit: uint64(conf.TransactionMaxGasLimit),
-				ScriptGasLimit:         uint64(conf.ScriptGasLimit),
-				TransactionExpiry:      uint(conf.TransactionExpiry),
-				StorageLimitEnabled:    conf.StorageLimitEnabled,
-				TransactionFeesEnabled: conf.TransactionFeesEnabled,
+				HTTPHeaders:               nil,
+				BlockTime:                 conf.BlockTime,
+				ServicePublicKey:          servicePublicKey,
+				ServiceKeySigAlgo:         serviceKeySigAlgo,
+				ServiceKeyHashAlgo:        serviceKeyHashAlgo,
+				Persist:                   conf.Persist,
+				DBPath:                    conf.DBPath,
+				GenesisTokenSupply:        parseCadenceUFix64(conf.TokenSupply, "token-supply"),
+				TransactionMaxGasLimit:    uint64(conf.TransactionMaxGasLimit),
+				ScriptGasLimit:            uint64(conf.ScriptGasLimit),
+				TransactionExpiry:         uint(conf.TransactionExpiry),
+				StorageLimitEnabled:       conf.StorageLimitEnabled,
+				StorageMBPerFLOW:          storageMBPerFLOW,
+				MinimumStorageReservation: minimumStorageReservation,
+				TransactionFeesEnabled:    conf.TransactionFeesEnabled,
 			}
 
 			emu := server.NewEmulatorServer(logger, serverConf)
@@ -184,13 +199,14 @@ func Exit(code int, msg string) {
 	os.Exit(code)
 }
 
-func parseTokenSupply(supply string) cadence.UFix64 {
-	tokenSupply, err := cadence.NewUFix64(supply)
+func parseCadenceUFix64(value string, valueName string) cadence.UFix64 {
+	tokenSupply, err := cadence.NewUFix64(value)
 	if err != nil {
 		Exit(
 			1,
 			fmt.Sprintf(
-				"Invalid token supply. Failed to parse `%s` as an unsigned 64-bit fixed-point number: %s",
+				"Failed to parse %s from value `%s` as an unsigned 64-bit fixed-point number: %s",
+				valueName,
 				conf.TokenSupply,
 				err.Error()),
 		)

--- a/cmd/emulator/start/start.go
+++ b/cmd/emulator/start/start.go
@@ -53,7 +53,7 @@ type Config struct {
 	TokenSupply            string        `default:"1000000000.0" flag:"token-supply" info:"initial FLOW token supply"`
 	TransactionExpiry      int           `default:"10" flag:"transaction-expiry" info:"transaction expiry, measured in blocks"`
 	StorageLimitEnabled    bool          `default:"true" flag:"storage-limit" info:"enable account storage limit"`
-	StorageMBPerFLOW       string        `flag:"storage-cost" info:"the MB amount of storage capacity an account has per 1 FLOW token it has. e.g. '100.0'. The default is taken from the current version of flow-go"`
+	StorageMBPerFLOW       string        `flag:"storage-per-flow" info:"the MB amount of storage capacity an account has per 1 FLOW token it has. e.g. '100.0'. The default is taken from the current version of flow-go"`
 	MinimumAccountBalance  string        `flag:"min-account-balance" info:"The minimum account balance of an account. This is also the cost of creating one account. e.g. '0.001'. The default is taken from the current version of flow-go"`
 	TransactionFeesEnabled bool          `default:"false" flag:"transaction-fees" info:"enable transaction fees"`
 	TransactionMaxGasLimit int           `default:"9999" flag:"transaction-max-gas-limit" info:"maximum gas limit for transactions"`
@@ -139,7 +139,7 @@ func Cmd(getServiceKey serviceKeyFunc) *cobra.Command {
 
 			storageMBPerFLOW := fvm.DefaultStorageMBPerFLOW
 			if conf.StorageMBPerFLOW != "" {
-				storageMBPerFLOW = parseCadenceUFix64(conf.StorageMBPerFLOW, "storage-cost")
+				storageMBPerFLOW = parseCadenceUFix64(conf.StorageMBPerFLOW, "storage-per-flow")
 			}
 
 			serverConf := &server.Config{

--- a/server/server.go
+++ b/server/server.go
@@ -74,21 +74,23 @@ var (
 
 // Config is the configuration for an emulator server.
 type Config struct {
-	GRPCPort               int
-	GRPCDebug              bool
-	HTTPPort               int
-	HTTPHeaders            []HTTPHeader
-	BlockTime              time.Duration
-	ServicePublicKey       crypto.PublicKey
-	ServiceKeySigAlgo      crypto.SignatureAlgorithm
-	ServiceKeyHashAlgo     crypto.HashAlgorithm
-	GenesisTokenSupply     cadence.UFix64
-	TransactionExpiry      uint
-	StorageLimitEnabled    bool
-	TransactionFeesEnabled bool
-	TransactionMaxGasLimit uint64
-	ScriptGasLimit         uint64
-	Persist                bool
+	GRPCPort                  int
+	GRPCDebug                 bool
+	HTTPPort                  int
+	HTTPHeaders               []HTTPHeader
+	BlockTime                 time.Duration
+	ServicePublicKey          crypto.PublicKey
+	ServiceKeySigAlgo         crypto.SignatureAlgorithm
+	ServiceKeyHashAlgo        crypto.HashAlgorithm
+	GenesisTokenSupply        cadence.UFix64
+	TransactionExpiry         uint
+	StorageLimitEnabled       bool
+	MinimumStorageReservation cadence.UFix64
+	StorageMBPerFLOW          cadence.UFix64
+	TransactionFeesEnabled    bool
+	TransactionMaxGasLimit    uint64
+	ScriptGasLimit            uint64
+	Persist                   bool
 	// DBPath is the path to the Badger database on disk.
 	DBPath string
 	// DBGCInterval is the time interval at which to garbage collect the Badger value log.
@@ -210,6 +212,8 @@ func configureBlockchain(conf *Config, store storage.Store) (*emulator.Blockchai
 		emulator.WithScriptGasLimit(conf.ScriptGasLimit),
 		emulator.WithTransactionExpiry(conf.TransactionExpiry),
 		emulator.WithStorageLimitEnabled(conf.StorageLimitEnabled),
+		emulator.WithMinimumStorageReservation(conf.MinimumStorageReservation),
+		emulator.WithStorageMBPerFLOW(conf.StorageMBPerFLOW),
 		emulator.WithTransactionFeesEnabled(conf.TransactionFeesEnabled),
 	}
 


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-emulator/issues/64

## Description

Introduced two new flags (or environment variables):

- `min-account-balance` flag controls  the minimum account balance (and consequentially account creation fees). example: `go run ./cmd/emulator/main.go --min-account-balance '0.04'`
- `storage-per-flow` flag sets the MB amount of storage capacity an account has per 1 FLOW token it has. example: `go run ./cmd/emulator/main.go --storage-per-flow '100.0'`

Both flags are strings that will be parsed as a cadence UFix64.

The defaults of both flags are taken from current version of `flow-go`. At the time of writing this task those values are:
- `min-account-balance  = 0.001`
- `storage-per-flow = 10.0`

## Side effect

I have reduced the default total token supply by a factor of 10. I did this otherwise the service account storage overflows if `storage-per-flow` is set to `100.00` which is the current mainnet value. This can be reverted after issue https://github.com/onflow/flow-core-contracts/issues/150 is resolved.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
