### PR TITLE
Adding debugging feature for failed signatures

### DIFF
--- a/types/error.go
+++ b/types/error.go
@@ -19,7 +19,12 @@
 package types
 
 import (
+	"fmt"
+
+	"github.com/onflow/flow-go/crypto/hash"
+
 	fvmerrors "github.com/onflow/flow-go/fvm/errors"
+	"github.com/onflow/flow-go/model/flow"
 )
 
 type FlowError struct {
@@ -32,4 +37,35 @@ func (f *FlowError) Error() string {
 
 func (f *FlowError) Unwrap() error {
 	return f.FlowError
+}
+
+type SignatureHashingError struct {
+	index        int
+	address      flow.Address
+	usedAlgo     hash.HashingAlgorithm
+	requiredAlgo hash.HashingAlgorithm
+}
+
+func NewSignatureHashingError(
+	index int,
+	address flow.Address,
+	usedAlgo hash.HashingAlgorithm,
+	requiredAlgo hash.HashingAlgorithm,
+) *SignatureHashingError {
+	return &SignatureHashingError{
+		index,
+		address,
+		usedAlgo,
+		requiredAlgo,
+	}
+}
+
+func (s *SignatureHashingError) Error() string {
+	return fmt.Sprintf(
+		"invalid hashing algorithm signature: public key %d on account %s does not have a valid signature: key requires %s hashing algorithm, but %s was used",
+		s.index,
+		s.address.Hex(),
+		s.requiredAlgo,
+		s.usedAlgo,
+	)
 }


### PR DESCRIPTION
Closes #70 

## Description
The emulator throws an error when it receives in an invalid transaction signature, but does not specify why the signature was invalid. Given that the emulator is a development tool, it should be able to perform an extra check to provide more diagnostics information to help the developer.

Functionality:
- Detects and report wrong hashing for a selected account
- Report transaction structure for signature errors during the verbose option

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
