### PR TITLE
Increment sequence number on transaction failure

### DIFF
--- a/blocks.go
+++ b/blocks.go
@@ -21,15 +21,11 @@ package emulator
 import (
 	"errors"
 
-	"github.com/onflow/flow-go/access"
 	"github.com/onflow/flow-go/fvm"
 	flowgo "github.com/onflow/flow-go/model/flow"
 
 	"github.com/onflow/flow-emulator/storage"
 )
-
-var _ fvm.Blocks = &blocks{}
-var _ access.Blocks = &blocks{}
 
 type blocks struct {
 	blockchain *Blockchain

--- a/blocks.go
+++ b/blocks.go
@@ -21,11 +21,16 @@ package emulator
 import (
 	"errors"
 
+	"github.com/onflow/flow-go/access"
+
 	"github.com/onflow/flow-go/fvm"
 	flowgo "github.com/onflow/flow-go/model/flow"
 
 	"github.com/onflow/flow-emulator/storage"
 )
+
+var _ fvm.Blocks = &blocks{}
+var _ access.Blocks = &blocks{}
 
 type blocks struct {
 	blockchain *Blockchain

--- a/pendingBlock.go
+++ b/pendingBlock.go
@@ -43,7 +43,7 @@ type pendingBlock struct {
 func newPendingBlock(prevBlock *flowgo.Block, ledgerView *delta.View) *pendingBlock {
 
 	return &pendingBlock{
-		height:             prevBlock.Header.Height + 1,
+		height: prevBlock.Header.Height + 1,
 		// the view increments by between 1 and MaxViewIncrease to match
 		// behaviour on a real network, where views are not consecutive
 		view:               prevBlock.Header.View + uint64(rand.Intn(MaxViewIncrease)+1),
@@ -82,7 +82,7 @@ func (b *pendingBlock) Block() *flowgo.Block {
 	return &flowgo.Block{
 		Header: &flowgo.Header{
 			Height:    b.height,
-			View: b.view,
+			View:      b.view,
 			ParentID:  b.parentID,
 			Timestamp: b.timestamp,
 		},
@@ -165,13 +165,12 @@ func (b *pendingBlock) ExecuteNextTransaction(
 		return nil, err
 	}
 
-	if tp.Err == nil {
-		b.events = append(b.events, tp.Events...)
-		err := b.ledgerView.MergeView(childView)
-		if err != nil {
-			// fail fast if fatal error occurs
-			return nil, err
-		}
+	b.events = append(b.events, tp.Events...)
+
+	err = b.ledgerView.MergeView(childView)
+	if err != nil {
+		// fail fast if fatal error occurs
+		return nil, err
 	}
 
 	b.transactionResults[tx.ID()] = IndexedTransactionResult{

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -880,6 +880,88 @@ func TestSubmitTransaction_Arguments(t *testing.T) {
 	})
 }
 
+func TestSubmitTransaction_ProposerSequence(t *testing.T) {
+	t.Run("Valid transaction increases sequence number", func(t *testing.T) {
+		b, err := emulator.NewBlockchain(
+			emulator.WithStorageLimitEnabled(false),
+		)
+		require.NoError(t, err)
+
+		script := []byte(`
+		  transaction {
+		    prepare(signer: AuthAccount) {}
+		  }
+		`)
+		prevSeq := b.ServiceKey().SequenceNumber
+
+		tx := flow.NewTransaction().
+			SetScript(script).
+			SetGasLimit(flowgo.DefaultMaxTransactionGasLimit).
+			SetProposalKey(b.ServiceKey().Address, b.ServiceKey().Index, b.ServiceKey().SequenceNumber).
+			SetPayer(b.ServiceKey().Address).
+			AddAuthorizer(b.ServiceKey().Address)
+
+		err = tx.SignEnvelope(b.ServiceKey().Address, b.ServiceKey().Index, b.ServiceKey().Signer())
+		assert.NoError(t, err)
+
+		err = b.AddTransaction(*tx)
+		assert.NoError(t, err)
+
+		result, err := b.ExecuteNextTransaction()
+		assert.NoError(t, err)
+		assertTransactionSucceeded(t, result)
+
+		_, err = b.CommitBlock()
+		assert.NoError(t, err)
+
+		tx1Result, err := b.GetTransactionResult(tx.ID())
+		assert.NoError(t, err)
+		assert.Equal(t, flow.TransactionStatusSealed, tx1Result.Status)
+
+		assert.Equal(t, prevSeq+1, b.ServiceKey().SequenceNumber)
+	})
+
+	t.Run("Reverted transaction increases sequence number", func(t *testing.T) {
+		b, err := emulator.NewBlockchain(
+			emulator.WithStorageLimitEnabled(false),
+		)
+		require.NoError(t, err)
+
+		prevSeq := b.ServiceKey().SequenceNumber
+		script := []byte(`
+		  transaction {
+			prepare(signer: AuthAccount) {} 
+			execute { panic("revert!") }
+		  }
+		`)
+
+		tx := flow.NewTransaction().
+			SetScript(script).
+			SetGasLimit(flowgo.DefaultMaxTransactionGasLimit).
+			SetProposalKey(b.ServiceKey().Address, b.ServiceKey().Index, b.ServiceKey().SequenceNumber).
+			SetPayer(b.ServiceKey().Address).
+			AddAuthorizer(b.ServiceKey().Address)
+
+		err = tx.SignEnvelope(b.ServiceKey().Address, b.ServiceKey().Index, b.ServiceKey().Signer())
+		assert.NoError(t, err)
+
+		err = b.AddTransaction(*tx)
+		assert.NoError(t, err)
+
+		_, err = b.ExecuteNextTransaction()
+		assert.NoError(t, err)
+
+		_, err = b.CommitBlock()
+		assert.NoError(t, err)
+
+		tx1Result, err := b.GetTransactionResult(tx.ID())
+		assert.NoError(t, err)
+		assert.Equal(t, flow.TransactionStatusSealed, tx1Result.Status)
+
+		assert.Equal(t, prevSeq+1, b.ServiceKey().SequenceNumber)
+	})
+}
+
 func TestGetTransaction(t *testing.T) {
 	b, err := emulator.NewBlockchain(
 		emulator.WithStorageLimitEnabled(false),
@@ -1150,7 +1232,7 @@ func TestHelloWorld_UpdateAccount(t *testing.T) {
 	if newAccountAddress == flow.EmptyAddress {
 		assert.Fail(t, "missing account created event")
 	}
-	
+
 	t.Logf("new account address: 0x%s", newAccountAddress.Hex())
 
 	account, err := b.GetAccount(newAccountAddress)

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -956,9 +956,10 @@ func TestSubmitTransaction_ProposerSequence(t *testing.T) {
 
 		tx1Result, err := b.GetTransactionResult(tx.ID())
 		assert.NoError(t, err)
-		assert.Equal(t, flow.TransactionStatusSealed, tx1Result.Status)
-
 		assert.Equal(t, prevSeq+1, b.ServiceKey().SequenceNumber)
+		assert.Equal(t, flow.TransactionStatusSealed, tx1Result.Status)
+		assert.Len(t, tx1Result.Events, 0)
+		assert.IsType(t, &emulator.ExecutionError{}, tx1Result.Error)
 	})
 }
 


### PR DESCRIPTION
Closes #67 

## Description
The sequence number on the proposal key wasn't increased in case of failed transactions since the view wasn't merged and stored. This PR introduces a test for that case and fixes the problem.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
