### PR TITLE
Emulator Feature: Report gas used

### DIFF
--- a/convert/vm.go
+++ b/convert/vm.go
@@ -35,11 +35,11 @@ func VMTransactionResultToEmulator(tp *fvm.TransactionProcedure) (*types.Transac
 	}
 
 	return &types.TransactionResult{
-		TransactionID:      txID,
+		TransactionID:   txID,
 		ComputationUsed: tp.ComputationUsed,
-		Error:              VMErrorToEmulator(tp.Err),
-		Logs:               tp.Logs,
-		Events:             sdkEvents,
+		Error:           VMErrorToEmulator(tp.Err),
+		Logs:            tp.Logs,
+		Events:          sdkEvents,
 	}, nil
 }
 

--- a/convert/vm.go
+++ b/convert/vm.go
@@ -36,7 +36,7 @@ func VMTransactionResultToEmulator(tp *fvm.TransactionProcedure) (*types.Transac
 
 	return &types.TransactionResult{
 		TransactionID:      txID,
-		ComputationGasUsed: tp.ComputationUsed,
+		ComputationUsed: tp.ComputationUsed,
 		Error:              VMErrorToEmulator(tp.Err),
 		Logs:               tp.Logs,
 		Events:             sdkEvents,

--- a/convert/vm.go
+++ b/convert/vm.go
@@ -35,10 +35,11 @@ func VMTransactionResultToEmulator(tp *fvm.TransactionProcedure) (*types.Transac
 	}
 
 	return &types.TransactionResult{
-		TransactionID: txID,
-		Error:         VMErrorToEmulator(tp.Err),
-		Logs:          tp.Logs,
-		Events:        sdkEvents,
+		TransactionID:      txID,
+		ComputationGasUsed: tp.ComputationUsed,
+		Error:              VMErrorToEmulator(tp.Err),
+		Logs:               tp.Logs,
+		Events:             sdkEvents,
 	}, nil
 }
 

--- a/convert/vm_test.go
+++ b/convert/vm_test.go
@@ -1,7 +1,7 @@
 /*
  * Flow Emulator
  *
- * Copyright 2019-2020 Dapper Labs, Inc.
+ * Copyright 2019-2021 Dapper Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/convert/vm_test.go
+++ b/convert/vm_test.go
@@ -59,7 +59,7 @@ func TestVm(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, flowEvents, tr.Events)
 
-		assert.Equal(t, tp.ComputationUsed, tr.ComputationGasUsed)
+		assert.Equal(t, tp.ComputationUsed, tr.ComputationUsed)
 		assert.Equal(t, tp.Err, tr.Error)
 	})
 }

--- a/convert/vm_test.go
+++ b/convert/vm_test.go
@@ -1,0 +1,65 @@
+/*
+ * Flow Emulator
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package convert_test
+
+import (
+	"testing"
+
+	"github.com/onflow/flow-go-sdk/test"
+	"github.com/onflow/flow-go/fvm"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/flow-emulator/convert"
+	sdkConvert "github.com/onflow/flow-emulator/convert/sdk"
+	flowgo "github.com/onflow/flow-go/model/flow"
+)
+
+func TestVm(t *testing.T) {
+	t.Run("should be able to convert", func(t *testing.T) {
+		idGenerator := test.IdentifierGenerator()
+
+		eventGenerator := test.EventGenerator()
+		event1, err := sdkConvert.SDKEventToFlow(eventGenerator.New())
+		assert.NoError(t, err)
+
+		event2, err := sdkConvert.SDKEventToFlow(eventGenerator.New())
+		assert.NoError(t, err)
+
+		tp := &fvm.TransactionProcedure{
+			ID:              flowgo.Identifier(idGenerator.New()),
+			Logs:            []string{"TestLog1", "TestLog2"},
+			Events:          []flowgo.Event{event1, event2},
+			ComputationUsed: 5,
+			Err:             nil,
+		}
+
+		tr, err := convert.VMTransactionResultToEmulator(tp)
+		assert.NoError(t, err)
+
+		assert.Equal(t, tp.ID, flowgo.Identifier(tr.TransactionID))
+		assert.Equal(t, tp.Logs, tr.Logs)
+
+		flowEvents, err := sdkConvert.FlowEventsToSDK(tp.Events)
+		assert.NoError(t, err)
+		assert.Equal(t, flowEvents, tr.Events)
+
+		assert.Equal(t, tp.ComputationUsed, tr.ComputationGasUsed)
+		assert.Equal(t, tp.Err, tr.Error)
+	})
+}

--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -583,10 +583,12 @@ func printTransactionResult(logger *logrus.Logger, result *types.TransactionResu
 	if result.Succeeded() {
 		logger.
 			WithField("txID", result.TransactionID.String()).
+			WithField("gasUsed", result.ComputationGasUsed).
 			Info("⭐  Transaction executed")
 	} else {
 		logger.
 			WithField("txID", result.TransactionID.String()).
+			WithField("gasUsed", result.ComputationGasUsed).
 			Warn("❗  Transaction reverted")
 	}
 

--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -583,12 +583,12 @@ func printTransactionResult(logger *logrus.Logger, result *types.TransactionResu
 	if result.Succeeded() {
 		logger.
 			WithField("txID", result.TransactionID.String()).
-			WithField("gasUsed", result.ComputationGasUsed).
+			WithField("computationUsed", result.ComputationUsed).
 			Info("⭐  Transaction executed")
 	} else {
 		logger.
 			WithField("txID", result.TransactionID.String()).
-			WithField("gasUsed", result.ComputationGasUsed).
+			WithField("computationUsed", result.ComputationUsed).
 			Warn("❗  Transaction reverted")
 	}
 

--- a/types/result.go
+++ b/types/result.go
@@ -19,9 +19,9 @@
 package types
 
 import (
-	flowgo "github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow-go-sdk"
+	flowgo "github.com/onflow/flow-go/model/flow"
 )
 
 type StorableTransactionResult struct {
@@ -33,11 +33,11 @@ type StorableTransactionResult struct {
 
 // A TransactionResult is the result of executing a transaction.
 type TransactionResult struct {
-	TransactionID      flow.Identifier
-	ComputationGasUsed uint64
-	Error              error
-	Logs               []string
-	Events             []flow.Event
+	TransactionID   flow.Identifier
+	ComputationUsed uint64
+	Error           error
+	Logs            []string
+	Events          []flow.Event
 }
 
 // Succeeded returns true if the transaction executed without errors.

--- a/types/result.go
+++ b/types/result.go
@@ -33,10 +33,11 @@ type StorableTransactionResult struct {
 
 // A TransactionResult is the result of executing a transaction.
 type TransactionResult struct {
-	TransactionID flow.Identifier
-	Error         error
-	Logs          []string
-	Events        []flow.Event
+	TransactionID      flow.Identifier
+	ComputationGasUsed uint64
+	Error              error
+	Logs               []string
+	Events             []flow.Event
 }
 
 // Succeeded returns true if the transaction executed without errors.

--- a/types/result_test.go
+++ b/types/result_test.go
@@ -35,21 +35,21 @@ func TestResult(t *testing.T) {
 		idGenerator := test.IdentifierGenerator()
 
 		trSucceed := &types.TransactionResult{
-			TransactionID:      idGenerator.New(),
-			ComputationGasUsed: 20,
-			Error:              nil,
-			Logs:               []string{},
-			Events:             []flow.Event{},
+			TransactionID:   idGenerator.New(),
+			ComputationUsed: 20,
+			Error:           nil,
+			Logs:            []string{},
+			Events:          []flow.Event{},
 		}
 		assert.True(t, trSucceed.Succeeded())
 		assert.False(t, trSucceed.Reverted())
 
 		trReverted := &types.TransactionResult{
-			TransactionID:      idGenerator.New(),
-			ComputationGasUsed: 20,
-			Error:              errors.New("transaction execution error"),
-			Logs:               []string{},
-			Events:             []flow.Event{},
+			TransactionID:   idGenerator.New(),
+			ComputationUsed: 20,
+			Error:           errors.New("transaction execution error"),
+			Logs:            []string{},
+			Events:          []flow.Event{},
 		}
 		assert.True(t, trReverted.Reverted())
 		assert.False(t, trReverted.Succeeded())

--- a/types/result_test.go
+++ b/types/result_test.go
@@ -1,0 +1,73 @@
+/*
+ * Flow Emulator
+ *
+ * Copyright 2019-2020 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go-sdk/test"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/flow-emulator/types"
+)
+
+func TestResult(t *testing.T) {
+	t.Run("should return correct boolean", func(t *testing.T) {
+		idGenerator := test.IdentifierGenerator()
+
+		trSucceed := &types.TransactionResult{
+			TransactionID:      idGenerator.New(),
+			ComputationGasUsed: 20,
+			Error:              nil,
+			Logs:               []string{},
+			Events:             []flow.Event{},
+		}
+		assert.True(t, trSucceed.Succeeded())
+
+		trReverted := &types.TransactionResult{
+			TransactionID:      idGenerator.New(),
+			ComputationGasUsed: 20,
+			Error:              errors.New("transaction execution error"),
+			Logs:               []string{},
+			Events:             []flow.Event{},
+		}
+		assert.True(t, trReverted.Reverted())
+
+		srSucceed := &types.ScriptResult{
+			ScriptID: idGenerator.New(),
+			Value:    cadence.Value(cadence.NewInt(1)),
+			Error:    nil,
+			Logs:     []string{},
+			Events:   []flow.Event{},
+		}
+		assert.True(t, srSucceed.Succeeded())
+
+		srReverted := &types.ScriptResult{
+			ScriptID: idGenerator.New(),
+			Value:    cadence.Value(cadence.NewInt(1)),
+			Error:    errors.New("transaction execution error"),
+			Logs:     []string{},
+			Events:   []flow.Event{},
+		}
+		assert.True(t, srReverted.Reverted())
+	})
+}

--- a/types/result_test.go
+++ b/types/result_test.go
@@ -42,6 +42,7 @@ func TestResult(t *testing.T) {
 			Events:             []flow.Event{},
 		}
 		assert.True(t, trSucceed.Succeeded())
+		assert.False(t, trSucceed.Reverted())
 
 		trReverted := &types.TransactionResult{
 			TransactionID:      idGenerator.New(),
@@ -51,6 +52,7 @@ func TestResult(t *testing.T) {
 			Events:             []flow.Event{},
 		}
 		assert.True(t, trReverted.Reverted())
+		assert.False(t, trReverted.Succeeded())
 
 		srSucceed := &types.ScriptResult{
 			ScriptID: idGenerator.New(),
@@ -60,6 +62,7 @@ func TestResult(t *testing.T) {
 			Events:   []flow.Event{},
 		}
 		assert.True(t, srSucceed.Succeeded())
+		assert.False(t, srSucceed.Reverted())
 
 		srReverted := &types.ScriptResult{
 			ScriptID: idGenerator.New(),
@@ -69,5 +72,6 @@ func TestResult(t *testing.T) {
 			Events:   []flow.Event{},
 		}
 		assert.True(t, srReverted.Reverted())
+		assert.False(t, srReverted.Succeeded())
 	})
 }


### PR DESCRIPTION
Closes: FLIP Fest issue 12 https://github.com/onflow/flip-fest/issues/12

## Description

There should be a way to see transaction gas (computation) usage.

With this change, the output result of the transaction execution will look like this

**BEFORE**
<img width="925" alt="スクリーンショット 2021-09-27 0 02 12" src="https://user-images.githubusercontent.com/10495516/134813254-3cacf2ff-0b82-4266-a526-33bf93b31bc8.png">

**AFTER**
<img width="1038" alt="スクリーンショット 2021-09-29 9 06 58" src="https://user-images.githubusercontent.com/10495516/135181639-756ca7fb-d326-4f73-9ab7-bd948e896f1a.png">


## Other

Since there was no specific test code for the standard output of "txID=xxxxxx" that is currently displayed, I decided that there was no need to add any specific test code for this change as well.

I checked to see if any changes were needed in this document, but it looks like no changes are needed.
https://docs.onflow.org/flow-cli/start-emulator/

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
