### PR TITLE
Emit emulator error message to stderr

### DIFF
--- a/cmd/emulator/start/start.go
+++ b/cmd/emulator/start/start.go
@@ -214,7 +214,7 @@ func initConfig(cmd *cobra.Command) {
 }
 
 func Exit(code int, msg string) {
-	fmt.Println(msg)
+	fmt.Fprintln(os.Stderr, msg)
 	os.Exit(code)
 }
 


### PR DESCRIPTION
Closes none

## Description

Currently, the overall error message are emitted to `stdout` while it should be `stderr` because there are error message.

This is also described in the cobra's official doc [Create rootCmd
](https://github.com/spf13/cobra/blob/master/user_guide.md#create-rootcmd)
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels → no permission
