### PR TITLE
Correctly respect the dev wallet's environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ and if you plan to run the emulator with Docker you must use the environment var
 | `--port`, `-p` | `FLOW_PORT` | `3569` | gRPC port to listen on |
 | `--rest-port` | `FLOW_RESTPORT` | `8888` | REST API port to listen on |
 | `--admin-port` | `FLOW_ADMINPORT` | `8080` | Admin API port to listen on |
-| `--dev-wallet` | `DEV_WALLET` | `false` | Enable local Dev Wallet server |
-| `--dev-wallet-port` | `DEV_WALLET_PORT` | `8701` | Port to run Dev Wallet server on |
+| `--dev-wallet` | `FLOW_DEVWALLET` | `false` | Enable local Dev Wallet server |
+| `--dev-wallet-port` | `FLOW_DEVWALLETPORT` | `8701` | Port to run Dev Wallet server on |
 | `--verbose`, `-v` | `FLOW_VERBOSE` | `false` | Enable verbose logging (useful for debugging) |
 | `--log-format` | `FLOW_LOGFORMAT` | `text` | Output log format (valid values `text`, `JSON`) |
 | `--block-time`, `-b` | `FLOW_BLOCKTIME` | `0` | Time between sealed blocks. Valid units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h` |

--- a/cmd/emulator/start/start.go
+++ b/cmd/emulator/start/start.go
@@ -42,7 +42,7 @@ type Config struct {
 	RestPort               int           `default:"8888" flag:"rest-port" info:"port to run the REST API"`
 	AdminPort              int           `default:"8080" flag:"admin-port" info:"port to run the admin API"`
 	DevWalletPort          int           `default:"8701" flag:"dev-wallet-port" info:"port to run Dev Wallet server"`
-	DevWalletEnabled       bool          `default:"false" flag:"dev-wallet" info:"enable local Dev Wallet server"`
+	DevWallet              bool          `default:"false" flag:"dev-wallet" info:"enable local Dev Wallet server"`
 	Verbose                bool          `default:"false" flag:"verbose,v" info:"enable verbose logging"`
 	LogFormat              string        `default:"text" flag:"log-format" info:"logging output format. Valid values (text, JSON)"`
 	BlockTime              time.Duration `flag:"block-time,b" info:"time between sealed blocks, e.g. '300ms', '-1.5h' or '2h45m'. Valid units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'"`
@@ -157,7 +157,7 @@ func Cmd(getServiceKey serviceKeyFunc) *cobra.Command {
 				RESTPort:         conf.RestPort,
 				RESTDebug:        conf.RESTDebug,
 				DevWalletPort:    conf.DevWalletPort,
-				DevWalletEnabled: conf.DevWalletEnabled,
+				DevWalletEnabled: conf.DevWallet,
 				// TODO: allow headers to be parsed from environment
 				HTTPHeaders:               nil,
 				BlockTime:                 conf.BlockTime,


### PR DESCRIPTION
Signed-off-by: KeisukeYamashita <19yamashita15@gmail.com>

Closes https://github.com/onflow/flow-emulator/issues/124

## Description

The current `README.md`'s dev wallet environment variables' descriptions are incorrect. This PR fixes that description.
Also, I suggested a change on the `FLOW_DEVWALLETENABLE` name. For consistency with the `--dev-wallet` flag IMO it's better to rename that to ``FLOW_DEVWALLET`. 

Thanks team!

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
