### PR TITLE
Fix typo `Github` to `GitHub`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,8 +12,8 @@ ______
 For contributor use:
 
 - [ ] Targeted PR against `master` branch
-- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
+- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
 - [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
 - [ ] Updated relevant documentation
-- [ ] Re-reviewed `Files changed` in the Github PR explorer
+- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
 - [ ] Added appropriate labels

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The emulator exposes a gRPC server that implements the Flow Access API, which is
 ### The Flowser Emulator Explorer
 
 There is also an block explorer GUI for the emulator, that will help you speed up development when using the emulator. 
-- [Flowser Github Repository](https://github.com/onflowser/flowser)
+- [Flowser GitHub Repository](https://github.com/onflowser/flowser)
 - [Flowser Documentation](https://github.com/onflowser/flowser#-contents)
 
 # Running


### PR DESCRIPTION
Signed-off-by: KeisukeYamashita <19yamashita15@gmail.com>

Closes #???

## Description

Just a tiny PR to fix the typo `GIthub`

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
