### PR TITLE
Fail with non-zero exit code

### DIFF
--- a/cmd/emulator/start/start.go
+++ b/cmd/emulator/start/start.go
@@ -181,6 +181,8 @@ func Cmd(getServiceKey serviceKeyFunc) *cobra.Command {
 			emu := server.NewEmulatorServer(logger, serverConf)
 			if emu != nil {
 				emu.Start()
+			} else {
+				Exit(-1, "")
 			}
 		},
 	}


### PR DESCRIPTION
## Description
This PR makes sure the emulator exits with non-zero code if ports are in use.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
