### PR TITLE
add workflow for detecting md file diffs and calling refresh

### DIFF
--- a/.github/workflows/call-refresh-doc.yml
+++ b/.github/workflows/call-refresh-doc.yml
@@ -1,0 +1,53 @@
+# This workflow is stored and called from each repository that contains documentation files
+name: call-refresh-doc
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v19
+      with:
+        files: |
+          docs/**/*.md
+          docs/**/*.mdx
+
+    # --- Log all diff info --- 
+    - name: Log the files commit SHA if any md/mdx files have diffs
+      continue-on-error: true
+      if: steps.changed-files.outputs.any_modified == 'true'
+      run: |
+        for file in ${{ steps.changed-files.outputs.all_modified_files }}; do
+          echo "$file was modified" with the commit ${{ github.sha }}
+        done
+        for file in ${{ steps.changed-files.outputs.added_files }}; do
+          echo "$file was added"
+        done
+        for file in ${{ steps.changed-files.outputs.deleted_files }}; do
+          echo "$file was deleted"
+        done
+        for file in ${{ steps.changed-files.outputs.all_modified_files }}; do
+          echo "$file was modified"
+        done
+    outputs: 
+      all_modified_files: ${{ steps.changed-files.outputs.all_modified_files }}
+      any_modified: ${{ steps.changed-files.outputs.any_modified }}
+
+  # --- If modified, call refresh --- 
+  call-refresh-workflow-passing-data:
+    runs-on: ubuntu-latest
+    needs: compare
+    if: ${{ needs.compare.outputs.all_modified_files != 0 }}
+    uses: onflow/flow/.github/workflows/refresh-doc.yml@master
+    with:
+      contentPaths: ${{ needs.compare.outputs.all_modified_files }}
+      repository: ${{ github.event.repository.name }}
+      commitSha: ${{ github.sha }}
+      


### PR DESCRIPTION
Closes [#67](https://github.com/onflow/next-docs-v1/issues/67)

## Description
Create Github Actions in Documentation Sources, aka github repositories:
There are 2 workflows: 1. call-refresh-doc, 2. refresh-doc. First parses the documentation for diffs, and calls the second if there are any.

This repo only has the first workflow, and will call the refresh-doc workflow in /flow https://github.com/onflow/flow/pull/953

Used tj-actions/changed-files@v18.7 to get all the doc files that were edited
Logs more detailed information (added, deleted, modified) for the diff files
Calls the doc site's refresh endpoint located in /flow with the content paths, SHA, and repository name
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
