### PR TITLE
Fix call-refresh-doc.yml

### DIFF
--- a/.github/workflows/call-refresh-doc.yml
+++ b/.github/workflows/call-refresh-doc.yml
@@ -42,7 +42,6 @@ jobs:
 
   # --- If modified, call refresh --- 
   call-refresh-workflow-passing-data:
-    runs-on: ubuntu-latest
     needs: compare
     if: ${{ needs.compare.outputs.all_modified_files != 0 }}
     uses: onflow/flow/.github/workflows/refresh-doc.yml@master


### PR DESCRIPTION
Remove runs-on which is required in 'act' but not in actual github actions
Fix, continuation of this merged change: https://github.com/onflow/flow-emulator/pull/152
Relevant to issue: https://github.com/onflow/next-docs-v1/issues/67