### PR TITLE
Upgrade flow-go (to include FVM logging API change)

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -386,6 +386,7 @@ func configureFVM(conf config, blocks *blocks) (*fvm.VirtualMachine, fvm.Context
 	vm := fvm.NewVirtualMachine(rt)
 
 	fvmOptions := []fvm.Option{
+		fvm.WithLogger(conf.Logger),
 		fvm.WithChain(conf.GetChainID().Chain()),
 		fvm.WithBlocks(blocks),
 		fvm.WithRestrictedDeployment(false),
@@ -396,11 +397,10 @@ func configureFVM(conf config, blocks *blocks) (*fvm.VirtualMachine, fvm.Context
 	}
 
 	if !conf.TransactionValidationEnabled {
-		fvmOptions = append(fvmOptions, fvm.WithTransactionProcessors(fvm.NewTransactionInvoker(zerolog.Nop())))
+		fvmOptions = append(fvmOptions, fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()))
 	}
 
 	ctx := fvm.NewContext(
-		conf.Logger,
 		fvmOptions...,
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.12.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/onflow/cadence v0.26.0
-	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20220824222936-c55dd1bfea94
+	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20220829184930-82493852fa22
 	github.com/onflow/flow-go-sdk v0.27.0
 	github.com/onflow/flow-go/crypto v0.24.4
 	github.com/onflow/flow-nft/lib/go/contracts v0.0.0-20220727161549-d59b1e547ac4

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.12.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/onflow/cadence v0.26.0
-	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20220829184930-82493852fa22
+	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20220901173643-b7c385a64812
 	github.com/onflow/flow-go-sdk v0.27.0
 	github.com/onflow/flow-go/crypto v0.24.4
 	github.com/onflow/flow-nft/lib/go/contracts v0.0.0-20220727161549-d59b1e547ac4

--- a/go.sum
+++ b/go.sum
@@ -552,10 +552,8 @@ github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-
 github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-797b149ceaaa/go.mod h1:JB2hWVxUjhMshUDNVQKfn4dzhhawOO+i3XjlhLMV5MM=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4zbY76O0Y28QB0766A=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0/go.mod h1:1zoTjp1KzNnOPkyqKmWKerUyf0gciw+e6tAEt0Ks3JE=
-github.com/onflow/flow-go v0.26.14-test-synchronization.0.20220824222936-c55dd1bfea94 h1:B3esRS/frJ/M9wGSgOKWTi/3ErZz7kURTRduADovcMA=
-github.com/onflow/flow-go v0.26.14-test-synchronization.0.20220824222936-c55dd1bfea94/go.mod h1:GWoOky8I7EWjMK1vwLGSAj/3c2eAjlIrC1GdWcIQe4k=
-github.com/onflow/flow-go v0.26.14-test-synchronization.0.20220829184930-82493852fa22 h1:v1CLQLX8MSt02qJNSFWxn0B4+cZ2bQ83WgtzslyAyV4=
-github.com/onflow/flow-go v0.26.14-test-synchronization.0.20220829184930-82493852fa22/go.mod h1:+ful9GwFsxpGLhtGhcvr4iWtijwxHGP62sGMEgsgYi4=
+github.com/onflow/flow-go v0.26.14-test-synchronization.0.20220901173643-b7c385a64812 h1:EG0bqK+tBZ0AmHEYN5oec9EFAmR0ly32TQO5uMvrXZ8=
+github.com/onflow/flow-go v0.26.14-test-synchronization.0.20220901173643-b7c385a64812/go.mod h1:+ful9GwFsxpGLhtGhcvr4iWtijwxHGP62sGMEgsgYi4=
 github.com/onflow/flow-go-sdk v0.20.0/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4JPdtvJoae1spIUBOFxA8=
 github.com/onflow/flow-go-sdk v0.24.0/go.mod h1:IoptMLPyFXWvyd9yYA6/4EmSeeozl6nJoIv4FaEMg74=
 github.com/onflow/flow-go-sdk v0.27.0 h1:b1ATYB721fjWpISExS59bGX+mmBcP+AlWqso0eoT790=

--- a/go.sum
+++ b/go.sum
@@ -554,6 +554,8 @@ github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4z
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0/go.mod h1:1zoTjp1KzNnOPkyqKmWKerUyf0gciw+e6tAEt0Ks3JE=
 github.com/onflow/flow-go v0.26.14-test-synchronization.0.20220824222936-c55dd1bfea94 h1:B3esRS/frJ/M9wGSgOKWTi/3ErZz7kURTRduADovcMA=
 github.com/onflow/flow-go v0.26.14-test-synchronization.0.20220824222936-c55dd1bfea94/go.mod h1:GWoOky8I7EWjMK1vwLGSAj/3c2eAjlIrC1GdWcIQe4k=
+github.com/onflow/flow-go v0.26.14-test-synchronization.0.20220829184930-82493852fa22 h1:v1CLQLX8MSt02qJNSFWxn0B4+cZ2bQ83WgtzslyAyV4=
+github.com/onflow/flow-go v0.26.14-test-synchronization.0.20220829184930-82493852fa22/go.mod h1:+ful9GwFsxpGLhtGhcvr4iWtijwxHGP62sGMEgsgYi4=
 github.com/onflow/flow-go-sdk v0.20.0/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4JPdtvJoae1spIUBOFxA8=
 github.com/onflow/flow-go-sdk v0.24.0/go.mod h1:IoptMLPyFXWvyd9yYA6/4EmSeeozl6nJoIv4FaEMg74=
 github.com/onflow/flow-go-sdk v0.27.0 h1:b1ATYB721fjWpISExS59bGX+mmBcP+AlWqso0eoT790=


### PR DESCRIPTION


## Description

There was a change in the logging API for the FVM: https://github.com/onflow/flow-go/pull/3117

This PR upgrades flow-go to that version
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
