### PR TITLE
Upgrade flow-go - remove old FVM constructors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.12.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/onflow/cadence v0.27.0
-	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221006164531-ac5e7c1492bc
+	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221006192037-6066b77a0aae
 	github.com/onflow/flow-go-sdk v0.28.0
 	github.com/onflow/flow-go/crypto v0.24.4
 	github.com/onflow/flow-nft/lib/go/contracts v0.0.0-20220727161549-d59b1e547ac4

--- a/go.sum
+++ b/go.sum
@@ -569,8 +569,8 @@ github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-
 github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-797b149ceaaa/go.mod h1:JB2hWVxUjhMshUDNVQKfn4dzhhawOO+i3XjlhLMV5MM=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4zbY76O0Y28QB0766A=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0/go.mod h1:1zoTjp1KzNnOPkyqKmWKerUyf0gciw+e6tAEt0Ks3JE=
-github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221006164531-ac5e7c1492bc h1:k0V6aePpiibX+tcsWbUWHKb6IN+dA9N3yy7ipDN4aJQ=
-github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221006164531-ac5e7c1492bc/go.mod h1:7A3pt/5AKE8Xk7R0WoflC08VlpHcKAvuA02dprlYoBA=
+github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221006192037-6066b77a0aae h1:WlFL5mZh5fp+LorpMO5Y+zB7/iyB+SW1Mgjx/pDw91U=
+github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221006192037-6066b77a0aae/go.mod h1:7A3pt/5AKE8Xk7R0WoflC08VlpHcKAvuA02dprlYoBA=
 github.com/onflow/flow-go-sdk v0.20.0/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4JPdtvJoae1spIUBOFxA8=
 github.com/onflow/flow-go-sdk v0.24.0/go.mod h1:IoptMLPyFXWvyd9yYA6/4EmSeeozl6nJoIv4FaEMg74=
 github.com/onflow/flow-go-sdk v0.28.0 h1:MkRKQcqCuHnjSoD7hQKw5WIMbhK9tdhMuEF6FdYivSc=


### PR DESCRIPTION
Resolving wrongly merged PR https://github.com/onflow/flow-emulator/pull/212

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
