### PR TITLE
Auto update to onflow/cadence v0.28.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.46
+          version: v1.50
           args: --timeout=10m
 
   docker:

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.12.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/onflow/cadence v0.28.0
-	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221007235929-a3f3a871c5ce
+	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221011174222-54840e416e81
 	github.com/onflow/flow-go-sdk v0.29.0
 	github.com/onflow/flow-go/crypto v0.24.4
 	github.com/onflow/flow-nft/lib/go/contracts v0.0.0-20220727161549-d59b1e547ac4

--- a/go.sum
+++ b/go.sum
@@ -579,8 +579,8 @@ github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-
 github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-797b149ceaaa/go.mod h1:JB2hWVxUjhMshUDNVQKfn4dzhhawOO+i3XjlhLMV5MM=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4zbY76O0Y28QB0766A=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0/go.mod h1:1zoTjp1KzNnOPkyqKmWKerUyf0gciw+e6tAEt0Ks3JE=
-github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221007235929-a3f3a871c5ce h1:O6bPH7thQNWbh6pVbPW+MhM0kF4XSMa6cQO9hT+bKtY=
-github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221007235929-a3f3a871c5ce/go.mod h1:WmDshMvR2IEQa4NOaz+edoSIR25b9zC22NuB64efvcM=
+github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221011174222-54840e416e81 h1:Wu7f5dERtu72hadhqNT/gZQTPKdxguWWBjqFDDSs9u0=
+github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221011174222-54840e416e81/go.mod h1:WmDshMvR2IEQa4NOaz+edoSIR25b9zC22NuB64efvcM=
 github.com/onflow/flow-go-sdk v0.20.0/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4JPdtvJoae1spIUBOFxA8=
 github.com/onflow/flow-go-sdk v0.24.0/go.mod h1:IoptMLPyFXWvyd9yYA6/4EmSeeozl6nJoIv4FaEMg74=
 github.com/onflow/flow-go-sdk v0.29.0 h1:dTQvTZkHsHMU3eEnHaE8JE2SOPeAIYx5CgTul5MgDYE=


### PR DESCRIPTION
## Description

Automatically update to:
- [onflow/cadence v0.28.0](https://github.com/onflow/cadence/releases/tag/v0.28.0)
- [onflow/flow-go-sdk v0.29.0](https://github.com/onflow/flow-go-sdk/releases/tag/v0.29.0)
- [onflow/flow-go 54840e416e81b46ee2885a5096f812eda7dadf94](https://github.com/onflow/flow-go/releases/tag/54840e416e81b46ee2885a5096f812eda7dadf94)

Also update CI to:
- golangci-lint 1.50.0, without it we are running into https://github.com/golangci/golangci-lint/issues/2859

