### PR TITLE
Upgrading flow-go (to include event index fix)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.12.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/onflow/cadence v0.28.0
-	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221011174222-54840e416e81
+	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221012204608-ed91c80fee2b
 	github.com/onflow/flow-go-sdk v0.29.0
 	github.com/onflow/flow-go/crypto v0.24.4
 	github.com/onflow/flow-nft/lib/go/contracts v0.0.0-20220727161549-d59b1e547ac4

--- a/go.sum
+++ b/go.sum
@@ -579,8 +579,8 @@ github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-
 github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-797b149ceaaa/go.mod h1:JB2hWVxUjhMshUDNVQKfn4dzhhawOO+i3XjlhLMV5MM=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4zbY76O0Y28QB0766A=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0/go.mod h1:1zoTjp1KzNnOPkyqKmWKerUyf0gciw+e6tAEt0Ks3JE=
-github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221011174222-54840e416e81 h1:Wu7f5dERtu72hadhqNT/gZQTPKdxguWWBjqFDDSs9u0=
-github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221011174222-54840e416e81/go.mod h1:WmDshMvR2IEQa4NOaz+edoSIR25b9zC22NuB64efvcM=
+github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221012204608-ed91c80fee2b h1:QIEm7fAG1RjtJFof4p966IS34CpdDRqOyboFnc0hkIE=
+github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221012204608-ed91c80fee2b/go.mod h1:WmDshMvR2IEQa4NOaz+edoSIR25b9zC22NuB64efvcM=
 github.com/onflow/flow-go-sdk v0.20.0/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4JPdtvJoae1spIUBOFxA8=
 github.com/onflow/flow-go-sdk v0.24.0/go.mod h1:IoptMLPyFXWvyd9yYA6/4EmSeeozl6nJoIv4FaEMg74=
 github.com/onflow/flow-go-sdk v0.29.0 h1:dTQvTZkHsHMU3eEnHaE8JE2SOPeAIYx5CgTul5MgDYE=


### PR DESCRIPTION
To include PR https://github.com/onflow/flow-go/pull/3371 

### Description
Upgrading version of `github.com/onflow/flow-go` to include the fix for event indexing problem

### Changelist
https://github.com/onflow/flow-go/compare/54840e416e81...ed91c80fee2b

### Test
- [X] `make test`
- [X] `make run`