### PR TITLE
Multi tenant emulator 

### DIFF
--- a/server/admin.go
+++ b/server/admin.go
@@ -115,6 +115,10 @@ func (h *HTTPServer) Stop() {
 	_ = h.httpServer.Shutdown(context.Background())
 }
 
+func (h *HTTPServer) Server() *http.Server {
+	return h.httpServer
+}
+
 func wrappedHandler(wrappedServer *grpcweb.WrappedGrpcServer, headers []HTTPHeader) http.HandlerFunc {
 	return func(res http.ResponseWriter, req *http.Request) {
 		setResponseHeaders(&res, headers)

--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -54,10 +54,12 @@ func (b *Backend) SetEmulator(emulator Emulator) {
 	b.emulator = emulator
 }
 
+// Allows backend to create emulator on demand
 func (b *Backend) SetEmulatorCreator(creator func(name string) (*emulator.Blockchain, error)) {
 	b.createEmulator = creator
 }
 
+// Switches active blockchain for current request
 func (b *Backend) SwitchEmulator(name string) error {
 	emulator, ok := b.emulators[name]
 	if ok {

--- a/server/rest.go
+++ b/server/rest.go
@@ -56,6 +56,9 @@ func (r *RestServer) Stop() {
 	_ = r.server.Shutdown(context.Background())
 }
 
+func (r *RestServer) Server() *http.Server {
+	return r.server
+}
 func NewRestServer(logger *logrus.Logger, be *backend.Backend, chain flow.Chain, host string, port int, debug bool) (*RestServer, error) {
 
 	debugLogger := zerolog.Logger{}

--- a/server/storage.go
+++ b/server/storage.go
@@ -45,6 +45,7 @@ type BadgerStorage struct {
 
 func NewBadgerStorage(
 	logger *logrus.Logger,
+	name string,
 	dbPath string,
 	gcInterval time.Duration,
 	gcDiscardRatio float64,
@@ -54,7 +55,7 @@ func NewBadgerStorage(
 ) (*BadgerStorage, error) {
 	store, err := badger.New(
 		badger.WithSnapshot(snapshot),
-		badger.WithPath(dbPath),
+		badger.WithPath(dbPath, name),
 		badger.WithTruncate(true),
 		badger.WithPersist(persist),
 	)

--- a/server/storage.go
+++ b/server/storage.go
@@ -55,7 +55,8 @@ func NewBadgerStorage(
 ) (*BadgerStorage, error) {
 	store, err := badger.New(
 		badger.WithSnapshot(snapshot),
-		badger.WithPath(dbPath, name),
+		badger.WithPath(dbPath),
+		badger.WithName(name),
 		badger.WithTruncate(true),
 		badger.WithPersist(persist),
 	)

--- a/storage/badger/config.go
+++ b/storage/badger/config.go
@@ -19,6 +19,8 @@
 package badger
 
 import (
+	"fmt"
+
 	"github.com/dgraph-io/badger/v2"
 )
 
@@ -79,9 +81,12 @@ var defaultConfig = Config{
 
 type Opt func(*Config)
 
-func WithPath(path string) Opt {
+func WithPath(path string, name string) Opt {
 	return func(c *Config) {
 		c.DBPath = path
+		if name != "" {
+			c.DBPath = fmt.Sprintf("%s/%s", c.DBPath, name)
+		}
 		c.InMemory = false
 	}
 }

--- a/storage/badger/config.go
+++ b/storage/badger/config.go
@@ -38,6 +38,8 @@ type Config struct {
 	BadgerOptions badger.Options
 	// In Memory
 	InMemory bool
+	// Tenant Name (for multitenant)
+	Name string
 }
 
 // getBadgerconfig returns configuration object with  options and
@@ -54,6 +56,9 @@ func getBadgerConfig(opts ...Opt) Config {
 	if conf.InMemory {
 		conf.BadgerOptions = badger.DefaultOptions("")
 	} else {
+		if conf.Name != "" {
+			conf.BadgerOptions = badger.DefaultOptions(fmt.Sprintf("%s/%s", conf.DBPath, conf.Name))
+		}
 		conf.BadgerOptions = badger.DefaultOptions(conf.DBPath)
 	}
 
@@ -81,15 +86,19 @@ var defaultConfig = Config{
 
 type Opt func(*Config)
 
-func WithPath(path string, name string) Opt {
+func WithPath(path string) Opt {
 	return func(c *Config) {
 		c.DBPath = path
-		if name != "" {
-			c.DBPath = fmt.Sprintf("%s/%s", c.DBPath, name)
-		}
 		c.InMemory = false
 	}
 }
+
+func WithName(name string) Opt {
+	return func(c *Config) {
+		c.Name = name
+	}
+}
+
 func WithSnapshot(enabled bool) Opt {
 	return func(c *Config) {
 		c.Snapshot = enabled


### PR DESCRIPTION
Closes #207 

## Description

This is a small PR allowing using HTTP header `Emulator` to quickly start a new blockchain instance and switch between them with `Emulator: [someIdentifier]`

This is also on the idea phase, and we can discuss over it, but I think it can be very useful, as flow-js-testing etc, always launching new emulator instances, starting and stopping emulators. 

This can also let few users to use a single emulator server concurrently. (no port clashes etc) 

______

For contributor use:

- [X] Targeted PR against `master` branch
- [X] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [X] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
