### PR TITLE
Add interaction logs

### DIFF
--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -592,6 +592,11 @@ func (b *Backend) CommitBlock() {
 	}).Debugf("📦  Block #%d committed", block.Header.Height)
 }
 
+type ScriptResultWithLogs struct {
+	types.ScriptResult
+	Logs []string
+}
+
 // executeScriptAtBlock is a helper for executing a script at a specific block
 func (b *Backend) executeScriptAtBlock(script []byte, arguments [][]byte, blockHeight uint64) ([]byte, error) {
 	result, err := b.emulator.ExecuteScriptAtBlock(script, arguments, blockHeight)
@@ -605,7 +610,10 @@ func (b *Backend) executeScriptAtBlock(script []byte, arguments [][]byte, blockH
 		return nil, result.Error
 	}
 
-	valueBytes, err := jsoncdc.Encode(result.Value)
+	valueBytes, err := json.Marshal(ScriptResultWithLogs{
+		ScriptResult: *result,
+		Logs:         result.Logs,
+	})
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/server/emulator.go
+++ b/server/emulator.go
@@ -20,6 +20,7 @@ package server
 
 import (
 	"encoding/json"
+	flowgo "github.com/onflow/flow-go/model/flow"
 	"net/http"
 
 	fvmerrors "github.com/onflow/flow-go/fvm/errors"
@@ -55,6 +56,7 @@ func NewEmulatorAPIServer(server *EmulatorServer, backend *backend.Backend, stor
 	router.HandleFunc("/emulator/newBlock", r.CommitBlock)
 	router.HandleFunc("/emulator/snapshot/{name}", r.Snapshot)
 	router.HandleFunc("/emulator/storages/{address}", r.Storage)
+	router.HandleFunc("/emulator/logs/{txId}", r.Logs)
 
 	return r
 }
@@ -84,6 +86,20 @@ func (m EmulatorAPIServer) CommitBlock(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+}
+
+func (m EmulatorAPIServer) Logs(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	vars := mux.Vars(r)
+	txId := vars["txId"]
+
+	res, err := json.Marshal(m.backend.GetLogs(txId)
+	if err != nil {
+		m.server.logger.Error("Can't marshal logs")
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(res)
 }
 
 func (m EmulatorAPIServer) Snapshot(w http.ResponseWriter, r *http.Request) {

--- a/server/emulator.go
+++ b/server/emulator.go
@@ -20,7 +20,6 @@ package server
 
 import (
 	"encoding/json"
-	flowgo "github.com/onflow/flow-go/model/flow"
 	"net/http"
 
 	fvmerrors "github.com/onflow/flow-go/fvm/errors"

--- a/server/emulator.go
+++ b/server/emulator.go
@@ -92,7 +92,7 @@ func (m EmulatorAPIServer) Logs(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	txId := vars["txId"]
 
-	res, err := json.Marshal(m.backend.GetLogs(txId)
+	res, err := json.Marshal(m.backend.GetLogs(txId))
 	if err != nil {
 		m.server.logger.Error("Can't marshal logs")
 	}


### PR DESCRIPTION
## Description
- Transaction result can't be returned before new block is commited and all changes done by transaction are calculated and stored. I've added new admin endpoint, which will allow to access logs by transaction id at `/emulator/logs/{txId}`. This will keep Backend in complience with access.API interface and (technically 😅) shouldn't break existing solutions 🤞 
- Script result can be returned with HTTP request, so we create new type, which holds all the fields of ScriptResult, add new field `Logs` and then encode it as json

## Drawbacks
- gRPC endpoints are not implemented 😬

@sideninja need your advice on how to properly implement/improve this feature 🙇 

Closes #223 
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
