### PR TITLE
Update fvm meter/programs usage

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -30,8 +30,8 @@ import (
 	"github.com/onflow/flow-go/engine/execution/state/delta"
 	"github.com/onflow/flow-go/fvm"
 	fvmcrypto "github.com/onflow/flow-go/fvm/crypto"
+	"github.com/onflow/flow-go/fvm/environment"
 	fvmerrors "github.com/onflow/flow-go/fvm/errors"
-	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	flowgo "github.com/onflow/flow-go/model/flow"
@@ -547,9 +547,9 @@ func configureBootstrapProcedure(conf config, flowAccountKey flowgo.AccountPubli
 				common.ComputationKindStatement:          1569,
 				common.ComputationKindLoop:               1569,
 				common.ComputationKindFunctionInvocation: 1569,
-				meter.ComputationKindGetValue:            808,
-				meter.ComputationKindCreateAccount:       2837670,
-				meter.ComputationKindSetValue:            765,
+				environment.ComputationKindGetValue:      808,
+				environment.ComputationKindCreateAccount: 2837670,
+				environment.ComputationKindSetValue:      765,
 			}),
 		)
 	}
@@ -1028,13 +1028,19 @@ func (b *Blockchain) GetAccountStorage(address sdk.Address) (*AccountStorage, er
 		WithMaxValueSizeAllowed(b.vmCtx.MaxStateValueSize).
 		WithMaxInteractionSizeAllowed(math.MaxUint64)
 
+	txnPrograms, err := programs.NewEmptyBlockPrograms().
+		NewTransactionPrograms(0, 0)
+	if err != nil {
+		return nil, err
+	}
+
 	env := fvm.NewTransactionEnvironment(
 		b.vmCtx,
 		state.NewTransactionState(
 			view,
 			stateParameters,
 		),
-		programs.NewEmptyPrograms(),
+		txnPrograms,
 		flowgo.NewTransactionBody(),
 		0,
 		nil,

--- a/blocks.go
+++ b/blocks.go
@@ -23,13 +23,13 @@ import (
 
 	"github.com/onflow/flow-go/access"
 
-	"github.com/onflow/flow-go/fvm"
+	"github.com/onflow/flow-go/fvm/environment"
 	flowgo "github.com/onflow/flow-go/model/flow"
 
 	"github.com/onflow/flow-emulator/storage"
 )
 
-var _ fvm.Blocks = &blocks{}
+var _ environment.Blocks = &blocks{}
 var _ access.Blocks = &blocks{}
 
 type blocks struct {
@@ -67,6 +67,6 @@ func (b *blocks) FinalizedHeader() (*flowgo.Header, error) {
 }
 
 func (b *blocks) ByHeightFrom(height uint64, header *flowgo.Header) (*flowgo.Header, error) {
-	return fvm.NewBlockFinder(b.headers).
+	return environment.NewBlockFinder(b.headers).
 		ByHeightFrom(height, header)
 }


### PR DESCRIPTION
Closes #???

## Description

1. The canonical set of meter constants have been moved into the environment package
2. Blocks also got moved into the environment package
3. programs.Programs is deprecated

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
