### PR TITLE
Snapshot config logic fix

### DIFF
--- a/server/emulator.go
+++ b/server/emulator.go
@@ -84,7 +84,6 @@ func (m EmulatorAPIServer) CommitBlock(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
 }
 
 func (m EmulatorAPIServer) Snapshot(w http.ResponseWriter, r *http.Request) {

--- a/storage/badger/config.go
+++ b/storage/badger/config.go
@@ -82,6 +82,9 @@ type Opt func(*Config)
 func WithPath(path string) Opt {
 	return func(c *Config) {
 		c.DBPath = path
+		if path != "" {
+			c.InMemory = false
+		}
 	}
 }
 func WithSnapshot(enabled bool) Opt {

--- a/storage/badger/config.go
+++ b/storage/badger/config.go
@@ -82,13 +82,12 @@ type Opt func(*Config)
 func WithPath(path string) Opt {
 	return func(c *Config) {
 		c.DBPath = path
-		c.InMemory = false
 	}
 }
 func WithSnapshot(enabled bool) Opt {
 	return func(c *Config) {
 		c.Snapshot = enabled
-		c.InMemory = false
+		c.InMemory = c.InMemory && !enabled
 	}
 }
 func WithLogger(logger badger.Logger) Opt {
@@ -105,6 +104,6 @@ func WithTruncate(trunc bool) Opt {
 
 func WithPersist(persist bool) Opt {
 	return func(c *Config) {
-		c.InMemory = !persist
+		c.InMemory = c.InMemory && !persist
 	}
 }


### PR DESCRIPTION
Closes #227 

While introducing inmemory badger (after snapshots and persist separation) made a logic error on config parsing, this PR fixes that.  Also removes a header sent after content case. 
_____

For contributor use:

- [X] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [X] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
