### PR TITLE
Expose option for contract removal option

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -138,6 +138,7 @@ type config struct {
 	TransactionExpiry            uint
 	StorageLimitEnabled          bool
 	TransactionFeesEnabled       bool
+	ContractRemovalRestricted    bool
 	MinimumStorageReservation    cadence.UFix64
 	StorageMBPerFLOW             cadence.UFix64
 	Logger                       zerolog.Logger
@@ -338,6 +339,15 @@ func WithTransactionFeesEnabled(enabled bool) Option {
 	}
 }
 
+// WithContractRemovalRestricted restricts/allows removal of already deployed contracts.
+//
+// The default is provided by on-chain value.
+func WithContractRemovalRestricted(restricted bool) Option {
+	return func(c *config) {
+		c.ContractRemovalRestricted = restricted
+	}
+}
+
 // WithTransactionValidationEnabled enables/disables transaction validation.
 //
 // If set to false, the emulator will not verify transaction signatures or validate sequence numbers.
@@ -398,7 +408,8 @@ func configureFVM(conf config, blocks *blocks) (*fvm.VirtualMachine, fvm.Context
 		fvm.WithLogger(conf.Logger),
 		fvm.WithChain(conf.GetChainID().Chain()),
 		fvm.WithBlocks(blocks),
-		fvm.WithRestrictedDeployment(false),
+		fvm.WithContractDeploymentRestricted(false),
+		fvm.WithContractRemovalRestricted(conf.ContractRemovalRestricted),
 		fvm.WithGasLimit(conf.ScriptGasLimit),
 		fvm.WithCadenceLogging(true),
 		fvm.WithAccountStorageLimit(conf.StorageLimitEnabled),


### PR DESCRIPTION
## Description
Running an emulator programmatically it restricts removing of contracts, probably because that value is not set as part of the service contracts. Exposing to explicitly set that helps.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
