### PR TITLE
Separate listen and start methods on the emulator server

### DIFF
--- a/server/rest.go
+++ b/server/rest.go
@@ -33,19 +33,23 @@ import (
 )
 
 type RestServer struct {
-	logger   *logrus.Logger
-	host     string
-	port     int
-	server   *http.Server
-	listener net.Listener
+	logger *logrus.Logger
+	host   string
+	port   int
+	server *http.Server
 }
 
 func (r *RestServer) Start() error {
+	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", r.host, r.port))
+	if err != nil {
+		return err
+	}
+
 	r.logger.
 		WithField("port", r.port).
 		Infof("✅  Started REST API server on port %d", r.port)
 
-	err := r.server.Serve(r.listener)
+	err = r.server.Serve(l)
 	if err != nil {
 		return err
 	}
@@ -68,16 +72,10 @@ func NewRestServer(logger *logrus.Logger, be *backend.Backend, chain flow.Chain,
 		return nil, err
 	}
 
-	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
-	if err != nil {
-		return nil, err
-	}
-
 	return &RestServer{
-		logger:   logger,
-		host:     host,
-		port:     port,
-		server:   srv,
-		listener: l,
+		logger: logger,
+		host:   host,
+		port:   port,
+		server: srv,
 	}, nil
 }

--- a/server/rest.go
+++ b/server/rest.go
@@ -33,23 +33,34 @@ import (
 )
 
 type RestServer struct {
-	logger *logrus.Logger
-	host   string
-	port   int
-	server *http.Server
+	logger   *logrus.Logger
+	host     string
+	port     int
+	server   *http.Server
+	listener net.Listener
 }
 
-func (r *RestServer) Start() error {
+func (r *RestServer) Listen() error {
 	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", r.host, r.port))
 	if err != nil {
 		return err
+	}
+	r.listener = l
+	return nil
+}
+
+func (r *RestServer) Start() error {
+	if r.listener == nil {
+		if err := r.Listen(); err != nil {
+			return err
+		}
 	}
 
 	r.logger.
 		WithField("port", r.port).
 		Infof("✅  Started REST API server on port %d", r.port)
 
-	err = r.server.Serve(l)
+	err := r.server.Serve(r.listener)
 	if err != nil {
 		return err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -43,7 +43,6 @@ type EmulatorServer struct {
 	config     *Config
 	backend    *backend.Backend
 	group      *graceland.Group
-	listeners  []listener
 	liveness   graceland.Routine
 	storage    graceland.Routine
 	grpc       *GRPCServer
@@ -202,12 +201,7 @@ func NewEmulatorServer(logger *logrus.Logger, conf *Config) *EmulatorServer {
 // After this non-blocking function executes we can treat the
 // emulator server as ready.
 func (s *EmulatorServer) Listen() error {
-	s.listeners = make([]listener, 0)
-	s.listeners = append(s.listeners, s.grpc)
-	s.listeners = append(s.listeners, s.rest)
-	s.listeners = append(s.listeners, s.admin)
-
-	for _, lis := range s.listeners {
+	for _, lis := range []listener{s.grpc, s.rest, s.admin} {
 		err := lis.Listen()
 		if err != nil { // fail quick
 			return err


### PR DESCRIPTION
## Description
If the emulator is used as a package programmatically it's impossible to know when the server is actually up and listening since the Start method is blocking and doesn't signal when the server is ready. This PR adds the Listen method so you can explicitly call it and from that point onwards treat the server as ready. 

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
