### PR TITLE
Revert "Backend cleanup ( adapter removal )"

### DIFF
--- a/server/backend/adapter.go
+++ b/server/backend/adapter.go
@@ -1,0 +1,220 @@
+/*
+ * Flow Emulator
+ *
+ * Copyright 2019 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package backend
+
+import (
+	"context"
+
+	"github.com/onflow/flow-go/access"
+	flowgo "github.com/onflow/flow-go/model/flow"
+
+	convert "github.com/onflow/flow-emulator/convert/sdk"
+)
+
+var _ access.API = &Adapter{}
+
+// Adapter wraps the emulator backend to be compatible with access.API.
+type Adapter struct {
+	backend *Backend
+}
+
+// NewAdapter returns a new backend adapter.
+func NewAdapter(backend *Backend) *Adapter {
+	return &Adapter{backend: backend}
+}
+
+func (a *Adapter) Ping(ctx context.Context) error {
+	return a.backend.Ping(ctx)
+}
+
+func (a *Adapter) GetNetworkParameters(ctx context.Context) access.NetworkParameters {
+	return a.backend.GetNetworkParameters(ctx)
+}
+
+func (a *Adapter) GetLatestBlockHeader(ctx context.Context, isSealed bool) (*flowgo.Header, error) {
+	return a.backend.GetLatestBlockHeader(ctx, isSealed)
+}
+
+func (a *Adapter) GetBlockHeaderByHeight(ctx context.Context, height uint64) (*flowgo.Header, error) {
+	return a.backend.GetBlockHeaderByHeight(ctx, height)
+}
+
+func (a *Adapter) GetBlockHeaderByID(ctx context.Context, id flowgo.Identifier) (*flowgo.Header, error) {
+	return a.backend.GetBlockHeaderByID(ctx, convert.FlowIdentifierToSDK(id))
+}
+
+func (a *Adapter) GetLatestBlock(ctx context.Context, isSealed bool) (*flowgo.Block, error) {
+	return a.backend.GetLatestBlock(ctx, isSealed)
+}
+
+func (a *Adapter) GetBlockByHeight(ctx context.Context, height uint64) (*flowgo.Block, error) {
+	return a.backend.GetBlockByHeight(ctx, height)
+}
+
+func (a *Adapter) GetBlockByID(ctx context.Context, id flowgo.Identifier) (*flowgo.Block, error) {
+	return a.backend.GetBlockByID(ctx, convert.FlowIdentifierToSDK(id))
+}
+
+func (a *Adapter) GetCollectionByID(ctx context.Context, id flowgo.Identifier) (*flowgo.LightCollection, error) {
+	collection, err := a.backend.GetCollectionByID(ctx, convert.FlowIdentifierToSDK(id))
+	if err != nil {
+		return nil, err
+	}
+
+	return convert.SDKCollectionToFlow(collection), nil
+}
+
+func (a *Adapter) SendTransaction(ctx context.Context, tx *flowgo.TransactionBody) error {
+	return a.backend.SendTransaction(ctx, convert.FlowTransactionToSDK(*tx))
+}
+
+func (a *Adapter) GetTransaction(ctx context.Context, id flowgo.Identifier) (*flowgo.TransactionBody, error) {
+	tx, err := a.backend.GetTransaction(ctx, convert.FlowIdentifierToSDK(id))
+	if err != nil {
+		return nil, err
+	}
+
+	return convert.SDKTransactionToFlow(*tx), nil
+}
+
+func (a *Adapter) GetTransactionResult(ctx context.Context, id flowgo.Identifier) (*access.TransactionResult, error) {
+	result, err := a.backend.GetTransactionResult(ctx, convert.FlowIdentifierToSDK(id))
+	if err != nil {
+		return nil, err
+	}
+
+	flowResult, err := convert.SDKTransactionResultToFlow(result)
+	if err != nil {
+		return nil, err
+	}
+
+	return flowResult, nil
+}
+
+func (a *Adapter) GetAccount(ctx context.Context, address flowgo.Address) (*flowgo.Account, error) {
+	account, err := a.backend.GetAccount(ctx, convert.FlowAddressToSDK(address))
+	if err != nil {
+		return nil, err
+	}
+
+	flowAccount, err := convert.SDKAccountToFlow(account)
+	if err != nil {
+		return nil, err
+	}
+
+	return flowAccount, nil
+}
+
+func (a *Adapter) GetAccountAtLatestBlock(ctx context.Context, address flowgo.Address) (*flowgo.Account, error) {
+	account, err := a.backend.GetAccountAtLatestBlock(ctx, convert.FlowAddressToSDK(address))
+	if err != nil {
+		return nil, err
+	}
+
+	flowAccount, err := convert.SDKAccountToFlow(account)
+	if err != nil {
+		return nil, err
+	}
+
+	return flowAccount, nil
+}
+
+func (a *Adapter) GetAccountAtBlockHeight(
+	ctx context.Context,
+	address flowgo.Address,
+	height uint64,
+) (*flowgo.Account, error) {
+	account, err := a.backend.GetAccountAtBlockHeight(ctx, convert.FlowAddressToSDK(address), height)
+	if err != nil {
+		return nil, err
+	}
+
+	flowAccount, err := convert.SDKAccountToFlow(account)
+	if err != nil {
+		return nil, err
+	}
+
+	return flowAccount, nil
+}
+
+func (a *Adapter) ExecuteScriptAtLatestBlock(
+	ctx context.Context,
+	script []byte,
+	arguments [][]byte,
+) ([]byte, error) {
+	return a.backend.ExecuteScriptAtLatestBlock(ctx, script, arguments)
+}
+
+func (a *Adapter) ExecuteScriptAtBlockHeight(
+	ctx context.Context,
+	blockHeight uint64,
+	script []byte,
+	arguments [][]byte,
+) ([]byte, error) {
+	return a.backend.ExecuteScriptAtBlockHeight(ctx, blockHeight, script, arguments)
+}
+
+func (a *Adapter) ExecuteScriptAtBlockID(
+	ctx context.Context,
+	blockID flowgo.Identifier,
+	script []byte,
+	arguments [][]byte,
+) ([]byte, error) {
+	return a.backend.ExecuteScriptAtBlockID(ctx, convert.FlowIdentifierToSDK(blockID), script, arguments)
+}
+
+func (a *Adapter) GetEventsForHeightRange(
+	ctx context.Context,
+	eventType string,
+	startHeight, endHeight uint64,
+) ([]flowgo.BlockEvents, error) {
+	return a.backend.GetEventsForHeightRange(ctx, eventType, startHeight, endHeight)
+}
+
+func (a *Adapter) GetEventsForBlockIDs(
+	ctx context.Context,
+	eventType string,
+	blockIDs []flowgo.Identifier,
+) ([]flowgo.BlockEvents, error) {
+	return a.backend.GetEventsForBlockIDs(ctx, eventType, convert.FlowIdentifiersToSDK(blockIDs))
+}
+
+func (a *Adapter) GetLatestProtocolStateSnapshot(ctx context.Context) ([]byte, error) {
+	return a.backend.GetLatestProtocolStateSnapshot(ctx)
+}
+
+func (a *Adapter) GetExecutionResultForBlockID(ctx context.Context, blockID flowgo.Identifier) (*flowgo.ExecutionResult, error) {
+	return a.backend.GetExecutionResultForBlockID(ctx, blockID)
+}
+
+func (a *Adapter) GetExecutionResultByID(ctx context.Context, id flowgo.Identifier) (*flowgo.ExecutionResult, error) {
+	return nil, nil
+}
+
+func (a *Adapter) GetTransactionResultByIndex(ctx context.Context, blockID flowgo.Identifier, index uint32) (*access.TransactionResult, error) {
+	return a.backend.GetTransactionResultByIndex(ctx, blockID, index)
+}
+
+func (a *Adapter) GetTransactionsByBlockID(ctx context.Context, blockID flowgo.Identifier) ([]*flowgo.TransactionBody, error) {
+	return a.backend.GetTransactionsByBlockID(ctx, blockID)
+}
+
+func (a *Adapter) GetTransactionResultsByBlockID(ctx context.Context, blockID flowgo.Identifier) ([]*access.TransactionResult, error) {
+	return a.backend.GetTransactionResultsByBlockID(ctx, blockID)
+}

--- a/server/grpc.go
+++ b/server/grpc.go
@@ -47,8 +47,10 @@ func NewGRPCServer(logger *logrus.Logger, b *backend.Backend, chain flow.Chain, 
 		grpc.UnaryInterceptor(grpcprometheus.UnaryServerInterceptor),
 	)
 
-	legacyaccessproto.RegisterAccessAPIServer(grpcServer, legacyaccess.NewHandler(b, chain))
-	accessproto.RegisterAccessAPIServer(grpcServer, access.NewHandler(b, chain))
+	adaptedBackend := backend.NewAdapter(b)
+
+	legacyaccessproto.RegisterAccessAPIServer(grpcServer, legacyaccess.NewHandler(adaptedBackend, chain))
+	accessproto.RegisterAccessAPIServer(grpcServer, access.NewHandler(adaptedBackend, chain))
 
 	grpcprometheus.Register(grpcServer)
 

--- a/server/rest.go
+++ b/server/rest.go
@@ -63,7 +63,7 @@ func NewRestServer(logger *logrus.Logger, be *backend.Backend, chain flow.Chain,
 		debugLogger = zerolog.New(os.Stdout)
 	}
 
-	srv, err := rest.NewServer(be, "127.0.0.1:3333", debugLogger, chain)
+	srv, err := rest.NewServer(backend.NewAdapter(be), "127.0.0.1:3333", debugLogger, chain)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Reverts onflow/flow-emulator#220

Updating this into CLI made me realize that we probably shouldn't change the types of the backend. It's ok to remove the adapter as that's not used anywhere but changing types to flow-go types breaks any integration of the emulator. Also, I think returning SDK types makes it easier to use.

cc @bluesign 