### PR TITLE
Use script env instead of transaction env for GetAccountStorage

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -1045,16 +1045,14 @@ func (b *Blockchain) GetAccountStorage(address sdk.Address) (*AccountStorage, er
 		return nil, err
 	}
 
-	env := fvm.NewTransactionEnvironment(
-		b.vmCtx,
+	env := environment.NewScriptEnvironment(
+		context.Background(),
+		b.vmCtx.EnvironmentParams,
 		state.NewTransactionState(
 			view,
 			stateParameters,
 		),
 		txnPrograms,
-		flowgo.NewTransactionBody(),
-		0,
-		nil,
 	)
 
 	r := b.vmCtx.Borrow(env)


### PR DESCRIPTION
GetAccountStorage only needs read access.  Script env is sufficient.

Closes #???

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
