### PR TITLE
Remove WithMaxValueSizeAllowed from state setup

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"sync"
 	"time"
 
@@ -1036,8 +1035,7 @@ func (b *Blockchain) GetAccountStorage(address sdk.Address) (*AccountStorage, er
 
 	stateParameters := state.DefaultParameters().
 		WithMaxKeySizeAllowed(b.vmCtx.MaxStateKeySize).
-		WithMaxValueSizeAllowed(b.vmCtx.MaxStateValueSize).
-		WithMaxInteractionSizeAllowed(math.MaxUint64)
+		WithMaxValueSizeAllowed(b.vmCtx.MaxStateValueSize)
 
 	txnPrograms, err := programs.NewEmptyDerivedBlockData().
 		NewDerivedTransactionData(0, 0)


### PR DESCRIPTION
MaxUint64 is the default interaction limit, so there's no need to set it.

WithMaxValueSizeAllowed is getting deprecated in https://github.com/onflow/flow-go/pull/3588

Closes #???

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
