### PR TITLE
fixes accidentally enabled persist

### DIFF
--- a/storage/badger/config.go
+++ b/storage/badger/config.go
@@ -82,15 +82,14 @@ type Opt func(*Config)
 func WithPath(path string) Opt {
 	return func(c *Config) {
 		c.DBPath = path
-		if path != "" {
-			c.InMemory = false
-		}
 	}
 }
 func WithSnapshot(enabled bool) Opt {
 	return func(c *Config) {
 		c.Snapshot = enabled
-		c.InMemory = c.InMemory && !enabled
+		if enabled {
+			c.InMemory = false
+		}
 	}
 }
 func WithLogger(logger badger.Logger) Opt {
@@ -107,6 +106,8 @@ func WithTruncate(trunc bool) Opt {
 
 func WithPersist(persist bool) Opt {
 	return func(c *Config) {
-		c.InMemory = c.InMemory && !persist
+		if persist {
+			c.InMemory = false
+		}
 	}
 }


### PR DESCRIPTION
Closes #???

## Description

Somehow when rebasing backend changes, I missed some wrong merge :( that causes the emulator to enable persist mode even when the flag is not set. 

This PR should fix that. 
______

For contributor use:

- [X] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [X] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
