### PR TITLE
Add bluesign to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sideninja @psiemens @turbolent @janezpodhostnik
+* @sideninja @psiemens @turbolent @janezpodhostnik @bluesign


### PR DESCRIPTION
This is long overdue but @bluesign has been an amazing contributor to the Emulator and I want to make it an official codeowner of the codebase. 

Ofc only if you want it to.