### PR TITLE
Memstore

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -40,7 +40,7 @@ import (
 	"github.com/onflow/flow-emulator/convert"
 	sdkconvert "github.com/onflow/flow-emulator/convert/sdk"
 	"github.com/onflow/flow-emulator/storage"
-	"github.com/onflow/flow-emulator/storage/badger"
+	"github.com/onflow/flow-emulator/storage/memstore"
 	"github.com/onflow/flow-emulator/types"
 )
 
@@ -147,13 +147,13 @@ type config struct {
 }
 
 func (conf config) GetStore() storage.Store {
+	// if no store is specified, use a memstore
+	// NOTE: we don't initialize this in defaultConfig because otherwise the same
+	// memstore is shared between Blockchain instances
 	if conf.Store == nil {
-		store, err := badger.New(badger.WithPersist(false))
-		if err != nil {
-			panic("Cannot initialize memory storage")
-		}
-		conf.Store = store
+		return memstore.New()
 	}
+
 	return conf.Store
 }
 

--- a/blockchain.go
+++ b/blockchain.go
@@ -41,7 +41,6 @@ import (
 	"github.com/onflow/flow-emulator/convert"
 	sdkconvert "github.com/onflow/flow-emulator/convert/sdk"
 	"github.com/onflow/flow-emulator/storage"
-	"github.com/onflow/flow-emulator/storage/memstore"
 	"github.com/onflow/flow-emulator/types"
 )
 
@@ -154,9 +153,7 @@ func (conf config) GetStore() storage.Store {
 			panic("Cannot initialize memory storage")
 		}
 		conf.Store = store
-		return memstore.New()
 	}
-
 	return conf.Store
 }
 

--- a/blockchain.go
+++ b/blockchain.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/onflow/flow-emulator/storage/badger"
 	"sync"
 	"time"
 
@@ -41,6 +40,7 @@ import (
 	"github.com/onflow/flow-emulator/convert"
 	sdkconvert "github.com/onflow/flow-emulator/convert/sdk"
 	"github.com/onflow/flow-emulator/storage"
+	"github.com/onflow/flow-emulator/storage/badger"
 	"github.com/onflow/flow-emulator/types"
 )
 

--- a/blockchain.go
+++ b/blockchain.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/onflow/flow-emulator/storage/badger"
 	"sync"
 	"time"
 
@@ -147,10 +148,12 @@ type config struct {
 }
 
 func (conf config) GetStore() storage.Store {
-	// if no store is specified, use a memstore
-	// NOTE: we don't initialize this in defaultConfig because otherwise the same
-	// memstore is shared between Blockchain instances
 	if conf.Store == nil {
+		store, err := badger.New(badger.WithPersist(false))
+		if err != nil {
+			panic("Cannot initialize memory storage")
+		}
+		conf.Store = store
 		return memstore.New()
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -129,6 +129,7 @@ type listener interface {
 // NewEmulatorServer creates a new instance of a Flow Emulator server.
 func NewEmulatorServer(logger *logrus.Logger, conf *Config) *EmulatorServer {
 	conf = sanitizeConfig(conf)
+
 	store, err := configureStorage(logger, conf)
 	if err != nil {
 		logger.WithError(err).Error("❗  Failed to configure storage")

--- a/server/storage.go
+++ b/server/storage.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/onflow/flow-emulator/storage"
 	"github.com/onflow/flow-emulator/storage/badger"
+	"github.com/onflow/flow-emulator/storage/memstore"
 	"github.com/onflow/flow-emulator/storage/redis"
 )
 
@@ -54,6 +55,24 @@ func (s *RedisStorage) Start() error {
 func (s *RedisStorage) Stop() {}
 
 func (s *RedisStorage) Store() storage.Store {
+	return s.store
+}
+
+type MemoryStorage struct {
+	store *memstore.Store
+}
+
+func NewMemoryStorage() *MemoryStorage {
+	return &MemoryStorage{store: memstore.New()}
+}
+
+func (s *MemoryStorage) Start() error {
+	return nil
+}
+
+func (s *MemoryStorage) Stop() {}
+
+func (s *MemoryStorage) Store() storage.Store {
 	return s.store
 }
 

--- a/storage/memstore/memstore.go
+++ b/storage/memstore/memstore.go
@@ -1,0 +1,319 @@
+/*
+ * Flow Emulator
+ *
+ * Copyright 2019 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memstore
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/onflow/flow-go/engine/execution/state/delta"
+	"github.com/onflow/flow-go/fvm/utils"
+	flowgo "github.com/onflow/flow-go/model/flow"
+
+	"github.com/onflow/flow-emulator/storage"
+	"github.com/onflow/flow-emulator/types"
+)
+
+// Store implements the Store interface with an in-memory store.
+type Store struct {
+	mu sync.RWMutex
+	// block ID to block height
+	blockIDToHeight map[flowgo.Identifier]uint64
+	// blocks by height
+	blocks map[uint64]flowgo.Block
+	// collections by ID
+	collections map[flowgo.Identifier]flowgo.LightCollection
+	// transactions by ID
+	transactions map[flowgo.Identifier]flowgo.TransactionBody
+	// Transaction results by ID
+	transactionResults map[flowgo.Identifier]types.StorableTransactionResult
+	// Ledger states by block height
+	ledger map[uint64]*utils.MapLedger
+	// events by block height
+	eventsByBlockHeight map[uint64][]flowgo.Event
+	// highest block height
+	blockHeight uint64
+}
+
+// New returns a new in-memory Store implementation.
+func New() *Store {
+	return &Store{
+		mu:                  sync.RWMutex{},
+		blockIDToHeight:     make(map[flowgo.Identifier]uint64),
+		blocks:              make(map[uint64]flowgo.Block),
+		collections:         make(map[flowgo.Identifier]flowgo.LightCollection),
+		transactions:        make(map[flowgo.Identifier]flowgo.TransactionBody),
+		transactionResults:  make(map[flowgo.Identifier]types.StorableTransactionResult),
+		ledger:              make(map[uint64]*utils.MapLedger),
+		eventsByBlockHeight: make(map[uint64][]flowgo.Event),
+	}
+}
+
+var _ storage.Store = &Store{}
+
+func (s *Store) BlockByID(id flowgo.Identifier) (*flowgo.Block, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	blockHeight, ok := s.blockIDToHeight[id]
+	if !ok {
+		return nil, storage.ErrNotFound
+	}
+
+	block, ok := s.blocks[blockHeight]
+	if !ok {
+		return nil, storage.ErrNotFound
+	}
+
+	return &block, nil
+}
+
+func (s *Store) BlockByHeight(blockHeight uint64) (*flowgo.Block, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	block, ok := s.blocks[blockHeight]
+	if !ok {
+		return nil, storage.ErrNotFound
+	}
+
+	return &block, nil
+}
+
+func (s *Store) LatestBlock() (flowgo.Block, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	latestBlock, ok := s.blocks[s.blockHeight]
+	if !ok {
+		return flowgo.Block{}, storage.ErrNotFound
+	}
+	return latestBlock, nil
+}
+
+func (s *Store) StoreBlock(block *flowgo.Block) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.storeBlock(block)
+}
+
+func (s *Store) storeBlock(block *flowgo.Block) error {
+	s.blocks[block.Header.Height] = *block
+	s.blockIDToHeight[block.ID()] = block.Header.Height
+
+	if block.Header.Height > s.blockHeight {
+		s.blockHeight = block.Header.Height
+	}
+
+	return nil
+}
+
+func (s *Store) CommitBlock(
+	block flowgo.Block,
+	collections []*flowgo.LightCollection,
+	transactions map[flowgo.Identifier]*flowgo.TransactionBody,
+	transactionResults map[flowgo.Identifier]*types.StorableTransactionResult,
+	delta delta.Delta,
+	events []flowgo.Event,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(transactions) != len(transactionResults) {
+		return fmt.Errorf(
+			"transactions count (%d) does not match result count (%d)",
+			len(transactions),
+			len(transactionResults),
+		)
+	}
+
+	err := s.storeBlock(&block)
+	if err != nil {
+		return err
+	}
+
+	for _, col := range collections {
+		err := s.insertCollection(*col)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, tx := range transactions {
+		err := s.insertTransaction(tx.ID(), *tx)
+		if err != nil {
+			return err
+		}
+	}
+
+	for txID, result := range transactionResults {
+		err := s.insertTransactionResult(txID, *result)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = s.insertLedgerDelta(block.Header.Height, delta)
+	if err != nil {
+		return err
+	}
+
+	err = s.insertEvents(block.Header.Height, events)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Store) CollectionByID(colID flowgo.Identifier) (flowgo.LightCollection, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	tx, ok := s.collections[colID]
+	if !ok {
+		return flowgo.LightCollection{}, storage.ErrNotFound
+	}
+	return tx, nil
+}
+
+func (s *Store) insertCollection(col flowgo.LightCollection) error {
+	s.collections[col.ID()] = col
+	return nil
+}
+
+func (s *Store) TransactionByID(txID flowgo.Identifier) (flowgo.TransactionBody, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	tx, ok := s.transactions[txID]
+	if !ok {
+		return flowgo.TransactionBody{}, storage.ErrNotFound
+	}
+	return tx, nil
+}
+
+func (s *Store) insertTransaction(txID flowgo.Identifier, tx flowgo.TransactionBody) error {
+	s.transactions[txID] = tx
+	return nil
+}
+
+func (s *Store) TransactionResultByID(txID flowgo.Identifier) (types.StorableTransactionResult, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result, ok := s.transactionResults[txID]
+	if !ok {
+		return types.StorableTransactionResult{}, storage.ErrNotFound
+	}
+	return result, nil
+}
+
+func (s *Store) insertTransactionResult(txID flowgo.Identifier, result types.StorableTransactionResult) error {
+	s.transactionResults[txID] = result
+	return nil
+}
+
+func (s *Store) LedgerViewByHeight(blockHeight uint64) *delta.View {
+	return delta.NewView(func(owner, key string) (value flowgo.RegisterValue, err error) {
+
+		// Ledger.Get writes (!), so acquire a write lock!
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		ledger, ok := s.ledger[blockHeight]
+		if !ok {
+			return nil, nil
+		}
+
+		return ledger.Get(owner, key)
+	})
+}
+
+func (s *Store) UnsafeInsertLedgerDelta(blockHeight uint64, delta delta.Delta) error {
+	return s.insertLedgerDelta(blockHeight, delta)
+}
+
+func (s *Store) insertLedgerDelta(blockHeight uint64, delta delta.Delta) error {
+	var oldLedger *utils.MapLedger
+
+	// use empty ledger if this is the genesis block
+	if blockHeight == 0 {
+		oldLedger = utils.NewMapLedger()
+	} else {
+		oldLedger = s.ledger[blockHeight-1]
+	}
+
+	newLedger := utils.NewMapLedger()
+
+	// copy values from the previous ledger
+	for keyString, oldValue := range oldLedger.Registers {
+		value, exists := delta.Data[keyString]
+		if !exists || value.Value != nil {
+			newLedger.RegisterTouches[keyString] = true
+			newLedger.Registers[keyString] = oldValue
+		}
+	}
+
+	// write all updated values
+	ids, values := delta.RegisterUpdates()
+	for i, value := range values {
+		key := ids[i]
+		err := newLedger.Set(key.Owner, key.Key, value)
+		if err != nil {
+			return err
+		}
+	}
+
+	s.ledger[blockHeight] = newLedger
+
+	return nil
+}
+
+func (s *Store) EventsByHeight(blockHeight uint64, eventType string) ([]flowgo.Event, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	allEvents := s.eventsByBlockHeight[blockHeight]
+
+	events := make([]flowgo.Event, 0)
+
+	for _, event := range allEvents {
+		if eventType == "" {
+			events = append(events, event)
+		} else {
+			if string(event.Type) == eventType {
+				events = append(events, event)
+			}
+		}
+	}
+
+	return events, nil
+}
+
+func (s *Store) insertEvents(blockHeight uint64, events []flowgo.Event) error {
+	if s.eventsByBlockHeight[blockHeight] == nil {
+		s.eventsByBlockHeight[blockHeight] = events
+	} else {
+		s.eventsByBlockHeight[blockHeight] = append(s.eventsByBlockHeight[blockHeight], events...)
+	}
+
+	return nil
+}

--- a/storage/memstore/memstore_test.go
+++ b/storage/memstore/memstore_test.go
@@ -1,0 +1,120 @@
+/*
+ * Flow Emulator
+ *
+ * Copyright 2019 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memstore
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/onflow/flow-go/engine/execution/state/delta"
+	flowgo "github.com/onflow/flow-go/model/flow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemstore(t *testing.T) {
+
+	t.Parallel()
+
+	const blockHeight = 0
+	key := flowgo.RegisterID{
+		Owner: "",
+		Key:   "foo",
+	}
+	value := flowgo.RegisterEntry{
+		Key:   key,
+		Value: []byte("bar"),
+	}
+
+	store := New()
+
+	err := store.UnsafeInsertLedgerDelta(
+		blockHeight,
+		delta.Delta{
+			Data: map[string]flowgo.RegisterEntry{
+				key.String(): value,
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			view := store.LedgerViewByHeight(blockHeight)
+			actualValue, err := view.Get("", "foo")
+
+			require.NoError(t, err)
+			assert.Equal(t, value.Value, actualValue)
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestMemstoreSetValueToNil(t *testing.T) {
+
+	t.Parallel()
+
+	store := New()
+	key := flowgo.RegisterID{
+		Owner: "",
+		Key:   "foo",
+	}
+	value := flowgo.RegisterEntry{
+		Key:   key,
+		Value: []byte("bar"),
+	}
+	nilValue := flowgo.RegisterEntry{
+		Key:   key,
+		Value: nil,
+	}
+
+	// set initial value
+	err := store.insertLedgerDelta(0,
+		delta.Delta{
+			Data: map[string]flowgo.RegisterEntry{
+				key.String(): value,
+			},
+		})
+	require.NoError(t, err)
+
+	// check initial value
+	register, err := store.LedgerViewByHeight(0).Get(key.Owner, key.Key)
+	require.NoError(t, err)
+	require.Equal(t, string(value.Value), string(register))
+
+	// set value to nil
+	err = store.insertLedgerDelta(1,
+		delta.Delta{
+			Data: map[string]flowgo.RegisterEntry{
+				key.String(): nilValue,
+			},
+		})
+	require.NoError(t, err)
+
+	// check value is nil
+	register, err = store.LedgerViewByHeight(1).Get(key.Owner, key.Key)
+	require.NoError(t, err)
+	require.Equal(t, string(nilValue.Value), string(register))
+}


### PR DESCRIPTION
## Description
Putting back the memstore implementation as it serves well in cases where you use an emulator as a Go module and need to instantiate multiple instances. Since current alternative is only Badger which has a lot of overhead when used in-memory that is required. In the future I believe SQLite can also be added to the in-memory list, but I again believe that in cases where you need multiple instances spawn up it will still have the not needed overhead.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
