### PR TITLE
update emulator test

### DIFF
--- a/transaction_test.go
+++ b/transaction_test.go
@@ -716,7 +716,7 @@ func TestSubmitTransaction_EnvelopeSignature(t *testing.T) {
 
 		script := []byte(`
 		  transaction {
-		    prepare(signer: AuthAccount) {}
+		    prepare() {}
 		  }
 		`)
 


### PR DESCRIPTION
Closes #???

## Description

fvm returns additional errors after upgrading, due to preprocessing.

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

    
    
    ```
    [Error Code: 1101] error caused by: 2 errors occurred:
    * transaction preprocess failed: [Error Code: 1101] cadence runtime error: Execution failed:
    error: authorizer count mismatch for transaction: expected 0, got 1
    --> 1ae04fd007e8137d3a433f2248b34770a249f148fcd2405480b2c0076d5129d8
    
    * transaction verification failed: checking frozen account failed: cannot check account freeze status: [Error Code: 1201] account not found for address 01cf0e2f2f715450
    ```
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
