### PR TITLE
extension of Headers interface in `flow-go` repo

### DIFF
--- a/headers.go
+++ b/headers.go
@@ -68,6 +68,15 @@ func (h headers) ByHeight(height uint64) (*flowgo.Header, error) {
 	return block.Header, nil
 }
 
+// BlockIDByHeight returns the block ID that is finalized at the given height.
+func (h headers) BlockIDByHeight(height uint64) (flowgo.Identifier, error) {
+	h, err := h.ByHeight(height)
+	if err != nil {
+		return flowgo.ZeroID, err
+	}
+	return h.ID()
+}
+
 func (h headers) ByParentID(_ flowgo.Identifier) ([]*flowgo.Header, error) {
 	return nil, errors.New("not implemented")
 }

--- a/headers.go
+++ b/headers.go
@@ -74,7 +74,7 @@ func (h headers) BlockIDByHeight(height uint64) (flowgo.Identifier, error) {
 	if err != nil {
 		return flowgo.ZeroID, err
 	}
-	return header.ID()
+	return header.ID(), nil
 }
 
 func (h headers) ByParentID(_ flowgo.Identifier) ([]*flowgo.Header, error) {

--- a/headers.go
+++ b/headers.go
@@ -70,11 +70,11 @@ func (h headers) ByHeight(height uint64) (*flowgo.Header, error) {
 
 // BlockIDByHeight returns the block ID that is finalized at the given height.
 func (h headers) BlockIDByHeight(height uint64) (flowgo.Identifier, error) {
-	h, err := h.ByHeight(height)
+	header, err := h.ByHeight(height)
 	if err != nil {
 		return flowgo.ZeroID, err
 	}
-	return h.ID()
+	return header.ID()
 }
 
 func (h headers) ByParentID(_ flowgo.Identifier) ([]*flowgo.Header, error) {


### PR DESCRIPTION
in PR https://github.com/onflow/flow-go/pull/3824, we are extending the `Headers` interface. Also adding an implementation of the new method `BlockIDByHeight` `headers` implementation in the emulator repo.