### PR TITLE
Auto update to onflow/cadence v0.31.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.12.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/onflow/cadence v0.31.3
-	github.com/onflow/flow-go v0.28.1-0.20230118182935-47500faa8856
+	github.com/onflow/flow-go v0.28.1-0.20230120160936-441e9666309f
 	github.com/onflow/flow-go-sdk v0.31.3
 	github.com/onflow/flow-go/crypto v0.24.4
 	github.com/onflow/flow-nft/lib/go/contracts v0.0.0-20220727161549-d59b1e547ac4

--- a/go.sum
+++ b/go.sum
@@ -582,8 +582,8 @@ github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20221216161720-
 github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20221216161720-c1b31d5a4722/go.mod h1:WMmeggH/H9Xb/SsT+4QFMtGYf+p1S2LXzbZAIaQQWAk=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4zbY76O0Y28QB0766A=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0/go.mod h1:1zoTjp1KzNnOPkyqKmWKerUyf0gciw+e6tAEt0Ks3JE=
-github.com/onflow/flow-go v0.28.1-0.20230118182935-47500faa8856 h1:QnS1hA5M+wTNSo/J4ynf4AtR1ZKcuCDzTas5J8EsAMY=
-github.com/onflow/flow-go v0.28.1-0.20230118182935-47500faa8856/go.mod h1:atcwPnPjRlilSrr1GKV41PVwNW5X3fOJKCYinis4RzY=
+github.com/onflow/flow-go v0.28.1-0.20230120160936-441e9666309f h1:0ZoHkoOv3TIFFhQZB9xbYZVSa4WUzdhThzkEyntpEYs=
+github.com/onflow/flow-go v0.28.1-0.20230120160936-441e9666309f/go.mod h1:1eKi9Qot4WgOVaaLVfjEI97Bmk+SR62KFzeYpLl3uto=
 github.com/onflow/flow-go-sdk v0.24.0/go.mod h1:IoptMLPyFXWvyd9yYA6/4EmSeeozl6nJoIv4FaEMg74=
 github.com/onflow/flow-go-sdk v0.31.3 h1:CytMRiTayXRlkRNXQ9Cw6ZcKoOIK6+QtXk4iUb8f0zQ=
 github.com/onflow/flow-go-sdk v0.31.3/go.mod h1:cqj2QShwC4DqxWzrg0+U7KxE2k7OJDGBxh8XZrJ4v5E=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v0.31.3](https://github.com/onflow/cadence/releases/tag/v0.31.3)
- [onflow/flow-go-sdk v0.31.3](https://github.com/onflow/flow-go-sdk/releases/tag/v0.31.3)
- [onflow/flow-go 441e9666309f92c83349e3a904900fe217422b88](https://github.com/onflow/flow-go/releases/tag/441e9666309f92c83349e3a904900fe217422b88)

