### PR TITLE
Prevent crashing on stop if listener wasn't initialized

### DIFF
--- a/server/debugger/debugger.go
+++ b/server/debugger/debugger.go
@@ -117,6 +117,8 @@ func (d *Debugger) handleConnection(conn net.Conn) {
 func (d *Debugger) Stop() {
 	d.stopOnce.Do(func() {
 		close(d.quit)
-		d.listener.Close()
+		if d.listener != nil {
+			d.listener.Close()
+		}
 	})
 }


### PR DESCRIPTION
Closes #321 

## Description
If debugger listener wasn't created and stop signal is submitted then it crashes.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
