### PR TITLE
Expose Cadence Code Coverage through Flow Emulator

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -1555,5 +1555,5 @@ func (b *Blockchain) CoverageReport() *runtime.CoverageReport {
 }
 
 func (b *Blockchain) ResetCoverageReport() {
-	b.coverageReportedRuntime.CoverageReport = runtime.NewCoverageReport()
+	b.coverageReportedRuntime.Reset()
 }

--- a/blockchain.go
+++ b/blockchain.go
@@ -1554,6 +1554,10 @@ func (b *Blockchain) CoverageReport() *runtime.CoverageReport {
 	return b.coverageReportedRuntime.CoverageReport
 }
 
+func (b *Blockchain) SetCoverageReport(coverageReport *runtime.CoverageReport) {
+	b.coverageReportedRuntime.CoverageReport = coverageReport
+}
+
 func (b *Blockchain) ResetCoverageReport() {
 	b.coverageReportedRuntime.Reset()
 }

--- a/blockchain.go
+++ b/blockchain.go
@@ -69,6 +69,8 @@ type Blockchain struct {
 	currentScriptID        string
 
 	conf config
+
+	coverageReportedRuntime *CoverageReportedRuntime
 }
 
 type ServiceKey struct {
@@ -151,6 +153,7 @@ type config struct {
 	Logger                       zerolog.Logger
 	TransactionValidationEnabled bool
 	ChainID                      flowgo.ChainID
+	CoverageReportingEnabled     bool
 }
 
 func (conf config) GetStore() storage.Store {
@@ -206,6 +209,7 @@ var defaultConfig = func() config {
 		Logger:                       zerolog.Nop(),
 		TransactionValidationEnabled: true,
 		ChainID:                      flowgo.Emulator,
+		CoverageReportingEnabled:     false,
 	}
 }()
 
@@ -373,6 +377,18 @@ func WithChainID(chainID flowgo.ChainID) Option {
 		c.ChainID = chainID
 	}
 }
+
+// WithCoverageReportingEnabled enables/disables Cadence code coverage reporting.
+//
+// If set to false, the emulator will not collect/expose coverage information for Cadence code.
+//
+// The default is false.
+func WithCoverageReportingEnabled(enabled bool) Option {
+	return func(c *config) {
+		c.CoverageReportingEnabled = enabled
+	}
+}
+
 func (b *Blockchain) ReloadBlockchain() error {
 	var err error
 
@@ -484,6 +500,24 @@ func (b *Blockchain) LoadSnapshot(name string) error {
 func configureFVM(blockchain *Blockchain, conf config, blocks *blocks) (*fvm.VirtualMachine, fvm.Context, error) {
 	vm := fvm.NewVirtualMachine()
 
+	config := runtime.Config{
+		Debugger:                 blockchain.debugger,
+		AccountLinkingEnabled:    true,
+		CoverageReportingEnabled: conf.CoverageReportingEnabled,
+	}
+	coverageReportedRuntime := &CoverageReportedRuntime{
+		Runtime:        runtime.NewInterpreterRuntime(config),
+		CoverageReport: runtime.NewCoverageReport(),
+		Environment:    runtime.NewBaseInterpreterEnvironment(config),
+	}
+	customRuntimePool := reusableRuntime.NewCustomReusableCadenceRuntimePool(
+		1,
+		config,
+		func(config runtime.Config) runtime.Runtime {
+			return coverageReportedRuntime
+		},
+	)
+
 	fvmOptions := []fvm.Option{
 		fvm.WithLogger(conf.Logger),
 		fvm.WithChain(conf.GetChainID().Chain()),
@@ -494,14 +528,7 @@ func configureFVM(blockchain *Blockchain, conf config, blocks *blocks) (*fvm.Vir
 		fvm.WithCadenceLogging(true),
 		fvm.WithAccountStorageLimit(conf.StorageLimitEnabled),
 		fvm.WithTransactionFeesEnabled(conf.TransactionFeesEnabled),
-		fvm.WithReusableCadenceRuntimePool(
-			reusableRuntime.NewReusableCadenceRuntimePool(
-				1,
-				runtime.Config{
-					Debugger:              blockchain.debugger,
-					AccountLinkingEnabled: true,
-				}),
-		),
+		fvm.WithReusableCadenceRuntimePool(customRuntimePool),
 	}
 
 	if !conf.TransactionValidationEnabled {
@@ -514,6 +541,8 @@ func configureFVM(blockchain *Blockchain, conf config, blocks *blocks) (*fvm.Vir
 	ctx := fvm.NewContext(
 		fvmOptions...,
 	)
+
+	blockchain.coverageReportedRuntime = coverageReportedRuntime
 
 	return vm, ctx, nil
 }
@@ -698,11 +727,6 @@ func (b *Blockchain) newFVMContextFromHeader(header *flowgo.Header) fvm.Context 
 	return fvm.NewContextFromParent(
 		b.vmCtx,
 		fvm.WithBlockHeader(header),
-		fvm.WithReusableCadenceRuntimePool(
-			reusableRuntime.NewReusableCadenceRuntimePool(
-				1,
-				runtime.Config{Debugger: b.debugger, AccountLinkingEnabled: true}),
-		),
 	)
 }
 
@@ -1524,4 +1548,12 @@ func (b *Blockchain) SetDebugger(debugger *interpreter.Debugger) {
 
 func (b *Blockchain) EndDebugging() {
 	b.SetDebugger(nil)
+}
+
+func (b *Blockchain) CoverageReport() *runtime.CoverageReport {
+	return b.coverageReportedRuntime.CoverageReport
+}
+
+func (b *Blockchain) ResetCoverageReport() {
+	b.coverageReportedRuntime.CoverageReport = runtime.NewCoverageReport()
 }

--- a/cmd/emulator/start/start.go
+++ b/cmd/emulator/start/start.go
@@ -73,6 +73,7 @@ type Config struct {
 	ChainID                   string        `default:"emulator" flag:"chain-id" info:"chain to emulate for address generation. Valid values are: 'emulator', 'testnet', 'mainnet'"`
 	RedisURL                  string        `default:"" flag:"redis-url" info:"redis-server URL for persisting redis storage backend ( redis://[[username:]password@]host[:port][/database] ) "`
 	SqliteURL                 string        `default:"" flag:"sqlite-url" info:"sqlite db URL for persisting sqlite storage backend "`
+	CoverageReportingEnabled  bool          `default:"false" flag:"coverage-reporting" info:"enable Cadence code coverage reporting"`
 }
 
 const EnvPrefix = "FLOW"
@@ -191,6 +192,7 @@ func Cmd(getServiceKey serviceKeyFunc) *cobra.Command {
 				RedisURL:                  conf.RedisURL,
 				ContractRemovalEnabled:    conf.ContractRemovalEnabled,
 				SqliteURL:                 conf.SqliteURL,
+				CoverageReportingEnabled:  conf.CoverageReportingEnabled,
 			}
 
 			emu := server.NewEmulatorServer(logger, serverConf)

--- a/coverage_reported_runtime.go
+++ b/coverage_reported_runtime.go
@@ -1,0 +1,172 @@
+/*
+ * Flow Emulator
+ *
+ * Copyright 2019 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package emulator
+
+import (
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+	reusableRuntime "github.com/onflow/flow-go/fvm/runtime"
+)
+
+type CoverageReportedRuntime struct {
+	runtime.Runtime
+	runtime.Environment
+	*runtime.CoverageReport
+
+	fvmEnv reusableRuntime.Environment
+}
+
+func (crt *CoverageReportedRuntime) SetFvmEnvironment(
+	fvmEnv reusableRuntime.Environment,
+) {
+	crt.fvmEnv = fvmEnv
+}
+
+func (crt CoverageReportedRuntime) NewScriptExecutor(
+	script runtime.Script,
+	context runtime.Context,
+) runtime.Executor {
+	context.CoverageReport = crt.CoverageReport
+	return crt.Runtime.NewScriptExecutor(script, context)
+}
+
+func (crt CoverageReportedRuntime) NewTransactionExecutor(
+	script runtime.Script,
+	context runtime.Context,
+) runtime.Executor {
+	context.CoverageReport = crt.CoverageReport
+	return crt.Runtime.NewTransactionExecutor(script, context)
+}
+
+func (crt CoverageReportedRuntime) NewContractFunctionExecutor(
+	contractLocation common.AddressLocation,
+	functionName string,
+	arguments []cadence.Value,
+	argumentTypes []sema.Type,
+	context runtime.Context,
+) runtime.Executor {
+	context.CoverageReport = crt.CoverageReport
+	return crt.Runtime.NewContractFunctionExecutor(
+		contractLocation,
+		functionName,
+		arguments,
+		argumentTypes,
+		context,
+	)
+}
+
+func (crt CoverageReportedRuntime) SetDebugger(
+	debugger *interpreter.Debugger,
+) {
+	crt.Runtime.SetDebugger(debugger)
+}
+
+func (crt CoverageReportedRuntime) ExecuteScript(
+	script runtime.Script,
+	context runtime.Context,
+) (
+	cadence.Value,
+	error,
+) {
+	context.CoverageReport = crt.CoverageReport
+	return crt.Runtime.ExecuteScript(script, context)
+}
+
+func (crt CoverageReportedRuntime) ExecuteTransaction(
+	script runtime.Script,
+	context runtime.Context,
+) error {
+	context.CoverageReport = crt.CoverageReport
+	return crt.Runtime.ExecuteTransaction(script, context)
+}
+
+func (crt CoverageReportedRuntime) InvokeContractFunction(
+	contractLocation common.AddressLocation,
+	functionName string,
+	arguments []cadence.Value,
+	argumentTypes []sema.Type,
+	context runtime.Context,
+) (
+	cadence.Value,
+	error,
+) {
+	context.CoverageReport = crt.CoverageReport
+	return crt.Runtime.InvokeContractFunction(
+		contractLocation,
+		functionName,
+		arguments,
+		argumentTypes,
+		context,
+	)
+}
+
+func (crt CoverageReportedRuntime) ParseAndCheckProgram(
+	source []byte,
+	context runtime.Context,
+) (
+	*interpreter.Program,
+	error,
+) {
+	context.CoverageReport = crt.CoverageReport
+	return crt.Runtime.ParseAndCheckProgram(source, context)
+}
+
+func (crt *CoverageReportedRuntime) SetCoverageReport(
+	coverageReport *runtime.CoverageReport,
+) {
+	crt.CoverageReport = coverageReport
+}
+
+func (crt CoverageReportedRuntime) ReadStored(
+	address common.Address,
+	path cadence.Path,
+	context runtime.Context,
+) (
+	cadence.Value,
+	error,
+) {
+	context.CoverageReport = crt.CoverageReport
+	return crt.Runtime.ReadStored(address, path, context)
+}
+
+func (crt CoverageReportedRuntime) ReadLinked(
+	address common.Address,
+	path cadence.Path,
+	context runtime.Context,
+) (
+	cadence.Value,
+	error,
+) {
+	context.CoverageReport = crt.CoverageReport
+	return crt.Runtime.ReadLinked(address, path, context)
+}
+
+func (crt CoverageReportedRuntime) Storage(
+	context runtime.Context,
+) (
+	*runtime.Storage,
+	*interpreter.Interpreter,
+	error,
+) {
+	context.CoverageReport = crt.CoverageReport
+	return crt.Runtime.Storage(context)
+}

--- a/coverage_reported_runtime.go
+++ b/coverage_reported_runtime.go
@@ -24,82 +24,67 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
-	reusableRuntime "github.com/onflow/flow-go/fvm/runtime"
 )
 
 type CoverageReportedRuntime struct {
 	runtime.Runtime
 	runtime.Environment
 	*runtime.CoverageReport
-
-	fvmEnv reusableRuntime.Environment
 }
 
-func (crt *CoverageReportedRuntime) SetFvmEnvironment(
-	fvmEnv reusableRuntime.Environment,
-) {
-	crt.fvmEnv = fvmEnv
-}
-
-func (crt CoverageReportedRuntime) NewScriptExecutor(
+func (crr CoverageReportedRuntime) NewScriptExecutor(
 	script runtime.Script,
 	context runtime.Context,
 ) runtime.Executor {
-	context.CoverageReport = crt.CoverageReport
-	return crt.Runtime.NewScriptExecutor(script, context)
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.NewScriptExecutor(script, context)
 }
 
-func (crt CoverageReportedRuntime) NewTransactionExecutor(
-	script runtime.Script,
-	context runtime.Context,
-) runtime.Executor {
-	context.CoverageReport = crt.CoverageReport
-	return crt.Runtime.NewTransactionExecutor(script, context)
-}
-
-func (crt CoverageReportedRuntime) NewContractFunctionExecutor(
-	contractLocation common.AddressLocation,
-	functionName string,
-	arguments []cadence.Value,
-	argumentTypes []sema.Type,
-	context runtime.Context,
-) runtime.Executor {
-	context.CoverageReport = crt.CoverageReport
-	return crt.Runtime.NewContractFunctionExecutor(
-		contractLocation,
-		functionName,
-		arguments,
-		argumentTypes,
-		context,
-	)
-}
-
-func (crt CoverageReportedRuntime) SetDebugger(
-	debugger *interpreter.Debugger,
-) {
-	crt.Runtime.SetDebugger(debugger)
-}
-
-func (crt CoverageReportedRuntime) ExecuteScript(
+func (crr CoverageReportedRuntime) ExecuteScript(
 	script runtime.Script,
 	context runtime.Context,
 ) (
 	cadence.Value,
 	error,
 ) {
-	context.CoverageReport = crt.CoverageReport
-	return crt.Runtime.ExecuteScript(script, context)
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.ExecuteScript(script, context)
 }
 
-func (crt CoverageReportedRuntime) ExecuteTransaction(
+func (crr CoverageReportedRuntime) NewTransactionExecutor(
+	script runtime.Script,
+	context runtime.Context,
+) runtime.Executor {
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.NewTransactionExecutor(script, context)
+}
+
+func (crr CoverageReportedRuntime) ExecuteTransaction(
 	script runtime.Script,
 	context runtime.Context,
 ) error {
-	context.CoverageReport = crt.CoverageReport
-	return crt.Runtime.ExecuteTransaction(script, context)
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.ExecuteTransaction(script, context)
 }
 
-func (crt CoverageReportedRuntime) InvokeContractFunction(
+func (crr CoverageReportedRuntime) NewContractFunctionExecutor(
+	contractLocation common.AddressLocation,
+	functionName string,
+	arguments []cadence.Value,
+	argumentTypes []sema.Type,
+	context runtime.Context,
+) runtime.Executor {
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.NewContractFunctionExecutor(
+		contractLocation,
+		functionName,
+		arguments,
+		argumentTypes,
+		context,
+	)
+}
+
+func (crr CoverageReportedRuntime) InvokeContractFunction(
 	contractLocation common.AddressLocation,
 	functionName string,
 	arguments []cadence.Value,
@@ -109,8 +94,8 @@ func (crt CoverageReportedRuntime) InvokeContractFunction(
 	cadence.Value,
 	error,
 ) {
-	context.CoverageReport = crt.CoverageReport
-	return crt.Runtime.InvokeContractFunction(
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.InvokeContractFunction(
 		contractLocation,
 		functionName,
 		arguments,
@@ -119,21 +104,15 @@ func (crt CoverageReportedRuntime) InvokeContractFunction(
 	)
 }
 
-func (crt CoverageReportedRuntime) ParseAndCheckProgram(
+func (crr CoverageReportedRuntime) ParseAndCheckProgram(
 	source []byte,
 	context runtime.Context,
 ) (
 	*interpreter.Program,
 	error,
 ) {
-	context.CoverageReport = crt.CoverageReport
-	return crt.Runtime.ParseAndCheckProgram(source, context)
-}
-
-func (crt *CoverageReportedRuntime) SetCoverageReport(
-	coverageReport *runtime.CoverageReport,
-) {
-	crt.CoverageReport = coverageReport
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.ParseAndCheckProgram(source, context)
 }
 
 func (crt CoverageReportedRuntime) ReadStored(
@@ -148,7 +127,7 @@ func (crt CoverageReportedRuntime) ReadStored(
 	return crt.Runtime.ReadStored(address, path, context)
 }
 
-func (crt CoverageReportedRuntime) ReadLinked(
+func (crr CoverageReportedRuntime) ReadLinked(
 	address common.Address,
 	path cadence.Path,
 	context runtime.Context,
@@ -156,17 +135,17 @@ func (crt CoverageReportedRuntime) ReadLinked(
 	cadence.Value,
 	error,
 ) {
-	context.CoverageReport = crt.CoverageReport
-	return crt.Runtime.ReadLinked(address, path, context)
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.ReadLinked(address, path, context)
 }
 
-func (crt CoverageReportedRuntime) Storage(
+func (crr CoverageReportedRuntime) Storage(
 	context runtime.Context,
 ) (
 	*runtime.Storage,
 	*interpreter.Interpreter,
 	error,
 ) {
-	context.CoverageReport = crt.CoverageReport
-	return crt.Runtime.Storage(context)
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.Storage(context)
 }

--- a/server/emulator.go
+++ b/server/emulator.go
@@ -67,6 +67,7 @@ func NewEmulatorAPIServer(server *EmulatorServer, backend *backend.Backend) *Emu
 	router.HandleFunc("/emulator/config", r.Config)
 
 	router.HandleFunc("/emulator/codeCoverage", r.CodeCoverage).Methods("GET")
+	router.HandleFunc("/emulator/codeCoverage/reset", r.ResetCodeCoverage).Methods("PUT")
 
 	return r
 }
@@ -261,4 +262,12 @@ func (m EmulatorAPIServer) CodeCoverage(w http.ResponseWriter, r *http.Request) 
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+}
+
+func (m EmulatorAPIServer) ResetCodeCoverage(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	blockchain := m.server.blockchain
+
+	blockchain.ResetCoverageReport()
+	w.WriteHeader(http.StatusOK)
 }

--- a/server/emulator.go
+++ b/server/emulator.go
@@ -66,6 +66,8 @@ func NewEmulatorAPIServer(server *EmulatorServer, backend *backend.Backend) *Emu
 
 	router.HandleFunc("/emulator/config", r.Config)
 
+	router.HandleFunc("/emulator/codeCoverage", r.CodeCoverage).Methods("GET")
+
 	return r
 }
 
@@ -244,6 +246,17 @@ func (m EmulatorAPIServer) Storage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	err = json.NewEncoder(w).Encode(accountStorage)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}
+
+func (m EmulatorAPIServer) CodeCoverage(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	blockchain := m.server.blockchain
+
+	err := json.NewEncoder(w).Encode(blockchain.CoverageReport())
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/server/server.go
+++ b/server/server.go
@@ -129,6 +129,8 @@ type Config struct {
 	RedisURL string
 	//Sqlite URL for sqlite storage backend
 	SqliteURL string
+	// CoverageReportingEnabled enables/disables Cadence code coverage reporting.
+	CoverageReportingEnabled bool
 }
 
 type listener interface {
@@ -346,6 +348,7 @@ func configureBlockchain(conf *Config, store storage.Store) (*emulator.Blockchai
 		emulator.WithTransactionFeesEnabled(conf.TransactionFeesEnabled),
 		emulator.WithChainID(conf.ChainID),
 		emulator.WithContractRemovalEnabled(conf.ContractRemovalEnabled),
+		emulator.WithCoverageReportingEnabled(conf.CoverageReportingEnabled),
 	}
 
 	if conf.SkipTransactionValidation {


### PR DESCRIPTION
**Closes** https://github.com/onflow/flow-emulator/issues/333
**Depends On** https://github.com/onflow/flow-go/pull/4126

## Description

 Allow the Flow Emulator to utilize the built-in code coverage functionality from Cadence, and expose it to developers through:
- API (programmatic)
- HTTP endpoint (visual)
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
