### PR TITLE
Convert Cadence logs to realtime

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -499,10 +499,11 @@ type CadenceHook struct {
 }
 
 func (h CadenceHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
-	if level != zerolog.NoLevel && strings.HasPrefix(msg, "Cadence log:") {
+	const logPrefix = "Cadence log:"
+	if level != zerolog.NoLevel && strings.HasPrefix(msg, logPrefix) {
 		h.MainLogger.Info().Msg(
 			strings.Replace(msg,
-				"Cadence log:",
+				logPrefix,
 				aurora.Colorize("LOG:", aurora.BlueFg|aurora.BoldFm).String(),
 				1))
 	}

--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -732,14 +732,6 @@ func printTransactionResult(logger *zerolog.Logger, result *types.TransactionRes
 			Msg("❗  Transaction reverted")
 	}
 
-	for _, log := range result.Logs {
-		logger.Info().Msgf(
-			"%s %s",
-			logPrefix("LOG", result.TransactionID, aurora.BlueFg),
-			log,
-		)
-	}
-
 	for _, event := range result.Events {
 		logger.Debug().Msgf(
 			"%s %s",
@@ -772,14 +764,6 @@ func printScriptResult(logger *zerolog.Logger, result *types.ScriptResult) {
 			Str("scriptID", result.ScriptID.String()).
 			Uint64("computationUsed", result.ComputationUsed).
 			Msg("❗  Script reverted")
-	}
-
-	for _, log := range result.Logs {
-		logger.Debug().Msgf(
-			"%s %s",
-			logPrefix("LOG", result.ScriptID, aurora.BlueFg),
-			log,
-		)
 	}
 
 	if !result.Succeeded() {

--- a/server/server.go
+++ b/server/server.go
@@ -145,7 +145,7 @@ func NewEmulatorServer(logger *zerolog.Logger, conf *Config) *EmulatorServer {
 		return nil
 	}
 
-	blockchain, err := configureBlockchain(conf, store)
+	blockchain, err := configureBlockchain(logger, conf, store)
 	if err != nil {
 		logger.Err(err).Msg("❗  Failed to configure emulated blockchain")
 		return nil
@@ -333,8 +333,9 @@ func configureStorage(logger *zerolog.Logger, conf *Config) (storageProvider sto
 	return storageProvider, err
 }
 
-func configureBlockchain(conf *Config, store storage.Store) (*emulator.Blockchain, error) {
+func configureBlockchain(logger *zerolog.Logger, conf *Config, store storage.Store) (*emulator.Blockchain, error) {
 	options := []emulator.Option{
+		emulator.WithServerLogger(*logger),
 		emulator.WithStore(store),
 		emulator.WithGenesisTokenSupply(conf.GenesisTokenSupply),
 		emulator.WithTransactionMaxGasLimit(conf.TransactionMaxGasLimit),


### PR DESCRIPTION
Closes #302 

## Description

Converts cadence logs to realtime output instead of after script/transaction execution. 

______

For contributor use:

- [X] Targeted PR against `master` branch
- [X] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [X] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
