### PR TITLE
Expose `CoverageReport` through `Emulator` interface

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -14,10 +14,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/logrusorgru/aurora"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/logrusorgru/aurora"
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime"

--- a/server/backend/emulator.go
+++ b/server/backend/emulator.go
@@ -19,6 +19,7 @@
 package backend
 
 import (
+	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/interpreter"
 	emulator "github.com/onflow/flow-emulator"
 	sdk "github.com/onflow/flow-go-sdk"
@@ -29,8 +30,13 @@ import (
 
 // Emulator defines the method set of an emulated blockchain.
 type Emulator interface {
+	// Debugger
 	SetDebugger(*interpreter.Debugger)
 	EndDebugging()
+
+	// CoverageReport
+	CoverageReport() *runtime.CoverageReport
+	SetCoverageReport(coverageReport *runtime.CoverageReport)
 
 	AddTransaction(tx sdk.Transaction) error
 	ExecuteNextTransaction() (*types.TransactionResult, error)

--- a/server/backend/mocks/emulator.go
+++ b/server/backend/mocks/emulator.go
@@ -8,6 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	runtime "github.com/onflow/cadence/runtime"
 	interpreter "github.com/onflow/cadence/runtime/interpreter"
 	emulator "github.com/onflow/flow-emulator"
 	types "github.com/onflow/flow-emulator/types"
@@ -65,6 +66,20 @@ func (m *MockEmulator) CommitBlock() (*flow0.Block, error) {
 func (mr *MockEmulatorMockRecorder) CommitBlock() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitBlock", reflect.TypeOf((*MockEmulator)(nil).CommitBlock))
+}
+
+// CoverageReport mocks base method.
+func (m *MockEmulator) CoverageReport() *runtime.CoverageReport {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CoverageReport")
+	ret0, _ := ret[0].(*runtime.CoverageReport)
+	return ret0
+}
+
+// CoverageReport indicates an expected call of CoverageReport.
+func (mr *MockEmulatorMockRecorder) CoverageReport() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CoverageReport", reflect.TypeOf((*MockEmulator)(nil).CoverageReport))
 }
 
 // CreateSnapshot mocks base method.
@@ -375,6 +390,18 @@ func (m *MockEmulator) RollbackToBlockHeight(arg0 uint64) error {
 func (mr *MockEmulatorMockRecorder) RollbackToBlockHeight(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RollbackToBlockHeight", reflect.TypeOf((*MockEmulator)(nil).RollbackToBlockHeight), arg0)
+}
+
+// SetCoverageReport mocks base method.
+func (m *MockEmulator) SetCoverageReport(arg0 *runtime.CoverageReport) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetCoverageReport", arg0)
+}
+
+// SetCoverageReport indicates an expected call of SetCoverageReport.
+func (mr *MockEmulatorMockRecorder) SetCoverageReport(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCoverageReport", reflect.TypeOf((*MockEmulator)(nil).SetCoverageReport), arg0)
 }
 
 // SetDebugger mocks base method.


### PR DESCRIPTION
Work towards: https://github.com/onflow/developer-grants/issues/132

## Description

This will allow tools that build on-top of the Flow Emulator, to be able to inject/retrieve the `CoverageReport` object.
Context: https://github.com/bjartek/overflow/pull/107

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
