### PR TITLE
Display memory used (estimate) in script/transaction logs

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -1431,6 +1431,7 @@ func (b *Blockchain) ExecuteScriptAtBlock(
 		Logs:            output.Logs,
 		Events:          events,
 		ComputationUsed: output.ComputationUsed,
+		MemoryEstimate:  output.MemoryEstimate,
 	}, nil
 }
 

--- a/convert/vm.go
+++ b/convert/vm.go
@@ -44,6 +44,7 @@ func VMTransactionResultToEmulator(
 	return &types.TransactionResult{
 		TransactionID:   txID,
 		ComputationUsed: output.ComputationUsed,
+		MemoryEstimate:  output.MemoryEstimate,
 		Error:           VMErrorToEmulator(output.Err),
 		Logs:            output.Logs,
 		Events:          sdkEvents,

--- a/convert/vm_test.go
+++ b/convert/vm_test.go
@@ -52,6 +52,7 @@ func TestVm(t *testing.T) {
 			Logs:            []string{"TestLog1", "TestLog2"},
 			Events:          []flowgo.Event{event1, event2},
 			ComputationUsed: 5,
+			MemoryEstimate:  1211,
 			Err:             nil,
 		}
 
@@ -66,6 +67,7 @@ func TestVm(t *testing.T) {
 		assert.Equal(t, flowEvents, tr.Events)
 
 		assert.Equal(t, output.ComputationUsed, tr.ComputationUsed)
+		assert.Equal(t, output.MemoryEstimate, tr.MemoryEstimate)
 		assert.Equal(t, output.Err, tr.Error)
 	})
 }

--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -724,11 +724,13 @@ func printTransactionResult(logger *zerolog.Logger, result *types.TransactionRes
 		logger.Info().
 			Str("txID", result.TransactionID.String()).
 			Uint64("computationUsed", result.ComputationUsed).
+			Uint64("memoryEstimate", result.MemoryEstimate).
 			Msg("⭐  Transaction executed")
 	} else {
 		logger.Warn().
 			Str("txID", result.TransactionID.String()).
 			Uint64("computationUsed", result.ComputationUsed).
+			Uint64("memoryEstimate", result.MemoryEstimate).
 			Msg("❗  Transaction reverted")
 	}
 
@@ -758,11 +760,13 @@ func printScriptResult(logger *zerolog.Logger, result *types.ScriptResult) {
 		logger.Info().
 			Str("scriptID", result.ScriptID.String()).
 			Uint64("computationUsed", result.ComputationUsed).
+			Uint64("memoryEstimate", result.MemoryEstimate).
 			Msg("⭐  Script executed")
 	} else {
 		logger.Warn().
 			Str("scriptID", result.ScriptID.String()).
 			Uint64("computationUsed", result.ComputationUsed).
+			Uint64("memoryEstimate", result.MemoryEstimate).
 			Msg("❗  Script reverted")
 	}
 

--- a/types/result.go
+++ b/types/result.go
@@ -38,6 +38,7 @@ type StorableTransactionResult struct {
 type TransactionResult struct {
 	TransactionID   flowsdk.Identifier
 	ComputationUsed uint64
+	MemoryEstimate  uint64
 	Error           error
 	Logs            []string
 	Events          []flowsdk.Event
@@ -101,6 +102,7 @@ type ScriptResult struct {
 	Logs            []string
 	Events          []flowsdk.Event
 	ComputationUsed uint64
+	MemoryEstimate  uint64
 }
 
 // Succeeded returns true if the script executed without errors.

--- a/types/result_test.go
+++ b/types/result_test.go
@@ -43,6 +43,7 @@ func TestResult(t *testing.T) {
 		trSucceed := &types.TransactionResult{
 			TransactionID:   idGenerator.New(),
 			ComputationUsed: 20,
+			MemoryEstimate:  2048,
 			Error:           nil,
 			Logs:            []string{},
 			Events:          []flowsdk.Event{},
@@ -53,6 +54,7 @@ func TestResult(t *testing.T) {
 		trReverted := &types.TransactionResult{
 			TransactionID:   idGenerator.New(),
 			ComputationUsed: 20,
+			MemoryEstimate:  2048,
 			Error:           errors.New("transaction execution error"),
 			Logs:            []string{},
 			Events:          []flowsdk.Event{},


### PR DESCRIPTION
## Description

Adding this information to the logs, is a good first step in allowing Flow builders to gain some insight on profiling metrics of their contracts/scripts/transactions.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
