### PR TITLE
DB Path fix when deeper than 1 level 

### DIFF
--- a/storage/sqlite/store.go
+++ b/storage/sqlite/store.go
@@ -210,7 +210,7 @@ func New(url string) (store *Store, err error) {
 	if dbUrl != ":memory:" {
 		urlInfo, err := os.Stat(url)
 		if err == nil && urlInfo.IsDir() {
-			dbUrl = filepath.Join(urlInfo.Name(), "emulator.sqlite")
+			dbUrl = filepath.Join(url, "emulator.sqlite")
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Closes #378 

## Description

Fix for db path when path depth > 1 
______

For contributor use:

- [X] Targeted PR against `master` branch
- [X] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [X] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
