### PR TITLE
Create nightly builds

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -1,0 +1,42 @@
+name: Nightly Builds
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+env:
+  GO_VERSION: '1.19.2'
+  
+jobs:
+  build:
+    name: Build latest Flow Go
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Update Flow Go
+        run: go get github.com/onflow/flow-go@master
+
+      - name: Tidy up
+        run: go mod tidy
+
+      - name: Build
+        run: go build -v ./...
+        continue-on-error: true
+      
+      - name: create an issue
+        uses: dacbd/create-issue-action@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: Nightly Flow Go build failed
+          body: |
+            The build with the latest flow-go failed. Please investigate and fix the issue.
+
+            Workflow Run: ${{ github.run_number }}
+            Commit: ${{ github.sha }}
+            Ref: ${{ github.ref }}
+          assignees: j1010001


### PR DESCRIPTION
## Description
This creates nightly builds of Flow Go and creates an issue if the version breaks the emulator.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
