### PR TITLE
Simplify configuration for coverage reporting

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/flow-emulator/adapters"
 	"github.com/onflow/flow-emulator/emulator"
 	"github.com/onflow/flow-emulator/server/access"
@@ -373,7 +374,6 @@ func configureBlockchain(logger *zerolog.Logger, conf *Config, store storage.Sto
 		emulator.WithTransactionFeesEnabled(conf.TransactionFeesEnabled),
 		emulator.WithChainID(conf.ChainID),
 		emulator.WithContractRemovalEnabled(conf.ContractRemovalEnabled),
-		emulator.WithCoverageReportingEnabled(conf.CoverageReportingEnabled),
 	}
 
 	if conf.SkipTransactionValidation {
@@ -399,6 +399,13 @@ func configureBlockchain(logger *zerolog.Logger, conf *Config, store storage.Sto
 		options = append(
 			options,
 			emulator.WithServicePublicKey(conf.ServicePublicKey, conf.ServiceKeySigAlgo, conf.ServiceKeyHashAlgo),
+		)
+	}
+
+	if conf.CoverageReportingEnabled {
+		options = append(
+			options,
+			emulator.WithCoverageReport(runtime.NewCoverageReport()),
 		)
 	}
 


### PR DESCRIPTION
## Description

Keep only one `Option` function, for setting the `CoverageReport` to the `runtime.Config` object.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
