### PR TITLE
Fix emulator regressions

### DIFF
--- a/emulator/blockchain.go
+++ b/emulator/blockchain.go
@@ -294,6 +294,8 @@ type Blockchain struct {
 	currentScriptID        string
 
 	conf config
+
+	coverageReportedRuntime *CoverageReportedRuntime
 }
 
 // config is a set of configuration options for an emulated emulator.
@@ -513,6 +515,18 @@ func configureFVM(blockchain *Blockchain, conf config, blocks *blocks) (*fvm.Vir
 		AttachmentsEnabled:    true,
 		CoverageReport:        conf.CoverageReport,
 	}
+	coverageReportedRuntime := &CoverageReportedRuntime{
+		Runtime:        runtime.NewInterpreterRuntime(config),
+		CoverageReport: conf.CoverageReport,
+		Environment:    runtime.NewBaseInterpreterEnvironment(config),
+	}
+	customRuntimePool := reusableRuntime.NewCustomReusableCadenceRuntimePool(
+		1,
+		config,
+		func(config runtime.Config) runtime.Runtime {
+			return coverageReportedRuntime
+		},
+	)
 
 	fvmOptions := []fvm.Option{
 		fvm.WithLogger(cadenceLogger),
@@ -524,12 +538,7 @@ func configureFVM(blockchain *Blockchain, conf config, blocks *blocks) (*fvm.Vir
 		fvm.WithCadenceLogging(true),
 		fvm.WithAccountStorageLimit(conf.StorageLimitEnabled),
 		fvm.WithTransactionFeesEnabled(conf.TransactionFeesEnabled),
-		fvm.WithReusableCadenceRuntimePool(
-			reusableRuntime.NewReusableCadenceRuntimePool(
-				1,
-				config,
-			),
-		),
+		fvm.WithReusableCadenceRuntimePool(customRuntimePool),
 	}
 
 	if !conf.TransactionValidationEnabled {
@@ -542,6 +551,8 @@ func configureFVM(blockchain *Blockchain, conf config, blocks *blocks) (*fvm.Vir
 	ctx := fvm.NewContext(
 		fvmOptions...,
 	)
+
+	blockchain.coverageReportedRuntime = coverageReportedRuntime
 
 	return vm, ctx, nil
 }
@@ -1507,11 +1518,11 @@ func (b *Blockchain) EndDebugging() {
 }
 
 func (b *Blockchain) CoverageReport() *runtime.CoverageReport {
-	return b.conf.CoverageReport
+	return b.coverageReportedRuntime.CoverageReport
 }
 
 func (b *Blockchain) ResetCoverageReport() {
-	b.conf.CoverageReport.Reset()
+	b.coverageReportedRuntime.Reset()
 }
 
 func (b *Blockchain) GetTransactionsByBlockID(blockID flowgo.Identifier) ([]*flowgo.TransactionBody, error) {

--- a/emulator/blockchain.go
+++ b/emulator/blockchain.go
@@ -65,6 +65,12 @@ func New(opts ...Option) (*Blockchain, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(conf.Contracts) > 0 {
+		err := DeployContracts(b, conf.Contracts)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return b, nil
 
 }

--- a/emulator/coverage_reported_runtime.go
+++ b/emulator/coverage_reported_runtime.go
@@ -1,0 +1,152 @@
+/*
+ * Flow Emulator
+ *
+ * Copyright 2019 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package emulator
+
+import (
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+)
+
+type CoverageReportedRuntime struct {
+	runtime.Runtime
+	runtime.Environment
+	*runtime.CoverageReport
+}
+
+func (crr CoverageReportedRuntime) NewScriptExecutor(
+	script runtime.Script,
+	context runtime.Context,
+) runtime.Executor {
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.NewScriptExecutor(script, context)
+}
+
+func (crr CoverageReportedRuntime) ExecuteScript(
+	script runtime.Script,
+	context runtime.Context,
+) (
+	cadence.Value,
+	error,
+) {
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.ExecuteScript(script, context)
+}
+
+func (crr CoverageReportedRuntime) NewTransactionExecutor(
+	script runtime.Script,
+	context runtime.Context,
+) runtime.Executor {
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.NewTransactionExecutor(script, context)
+}
+
+func (crr CoverageReportedRuntime) ExecuteTransaction(
+	script runtime.Script,
+	context runtime.Context,
+) error {
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.ExecuteTransaction(script, context)
+}
+
+func (crr CoverageReportedRuntime) NewContractFunctionExecutor(
+	contractLocation common.AddressLocation,
+	functionName string,
+	arguments []cadence.Value,
+	argumentTypes []sema.Type,
+	context runtime.Context,
+) runtime.Executor {
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.NewContractFunctionExecutor(
+		contractLocation,
+		functionName,
+		arguments,
+		argumentTypes,
+		context,
+	)
+}
+
+func (crr CoverageReportedRuntime) InvokeContractFunction(
+	contractLocation common.AddressLocation,
+	functionName string,
+	arguments []cadence.Value,
+	argumentTypes []sema.Type,
+	context runtime.Context,
+) (
+	cadence.Value,
+	error,
+) {
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.InvokeContractFunction(
+		contractLocation,
+		functionName,
+		arguments,
+		argumentTypes,
+		context,
+	)
+}
+
+func (crr CoverageReportedRuntime) ParseAndCheckProgram(
+	source []byte,
+	context runtime.Context,
+) (
+	*interpreter.Program,
+	error,
+) {
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.ParseAndCheckProgram(source, context)
+}
+
+func (crr CoverageReportedRuntime) ReadStored(
+	address common.Address,
+	path cadence.Path,
+	context runtime.Context,
+) (
+	cadence.Value,
+	error,
+) {
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.ReadStored(address, path, context)
+}
+
+func (crr CoverageReportedRuntime) ReadLinked(
+	address common.Address,
+	path cadence.Path,
+	context runtime.Context,
+) (
+	cadence.Value,
+	error,
+) {
+	context.CoverageReport = crr.CoverageReport
+	//nolint:staticcheck
+	return crr.Runtime.ReadLinked(address, path, context)
+}
+
+func (crr CoverageReportedRuntime) Storage(
+	context runtime.Context,
+) (
+	*runtime.Storage,
+	*interpreter.Interpreter,
+	error,
+) {
+	context.CoverageReport = crr.CoverageReport
+	return crr.Runtime.Storage(context)
+}


### PR DESCRIPTION
## Description

- Bring back contract deployment logic (this was somehow lost in a big refactor)
- Bring back `CoverageReportedRuntime` as it is still required for coverage. The `ReusableCadenceRuntime` does not yet pass the `CoverageReport` from the `runtime.Config` object, to the `runtime.Context` object. See [here](https://github.com/onflow/flow-go/blob/9d528f75a73f467376412f57d106dc91d632d7d4/fvm/runtime/reusable_cadence_runtime.go#L67-L70).

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
