### PR TITLE
Nightly job fix - no issue on success

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -29,6 +29,7 @@ jobs:
         continue-on-error: true
       
       - name: create an issue
+        if: ${{ failure() }}
         uses: dacbd/create-issue-action@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix nightly flow-go build job

don't create issue on success
______

For contributor use:

- [X] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [X] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [X] Re-reviewed `Files changed` in the GitHub PR explorer
- [X] Added appropriate labels
