### PR TITLE
Update to latest Go SDK and flow-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/onflow/cadence v0.39.2
 	github.com/onflow/flow-archive v1.3.4-0.20230503192214-9e81e82d4dcc
-	github.com/onflow/flow-go v0.30.1-0.20230606183951-596485936163
-	github.com/onflow/flow-go-sdk v0.41.0
+	github.com/onflow/flow-go v0.31.1-0.20230606220911-189f62e4bc4d
+	github.com/onflow/flow-go-sdk v0.41.1
 	github.com/onflow/flow-go/crypto v0.24.7
 	github.com/onflow/flow-nft/lib/go/contracts v0.0.0-20220727161549-d59b1e547ac4
 	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230602212908-08fc6536d391

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/onflow/cadence v0.39.2
 	github.com/onflow/flow-archive v1.3.4-0.20230503192214-9e81e82d4dcc
-	github.com/onflow/flow-go v0.31.1-0.20230606220911-189f62e4bc4d
+	github.com/onflow/flow-go v0.31.1-0.20230606232908-66e59a929e3d
 	github.com/onflow/flow-go-sdk v0.41.1
 	github.com/onflow/flow-go/crypto v0.24.7
 	github.com/onflow/flow-nft/lib/go/contracts v0.0.0-20220727161549-d59b1e547ac4

--- a/go.sum
+++ b/go.sum
@@ -699,8 +699,8 @@ github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3 h1:X25A1dNajNUtE+K
 github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3/go.mod h1:dqAUVWwg+NlOhsuBHex7bEWmsUjsiExzhe/+t4xNH6A=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.0 h1:XEKE6qJUw3luhsYmIOteXP53gtxNxrwTohgxJXCYqBE=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.0/go.mod h1:kTMFIySzEJJeupk+7EmXs0EJ6CBWY/MV9fv9iYQk+RU=
-github.com/onflow/flow-go v0.31.1-0.20230606220911-189f62e4bc4d h1:2owezgewMpB2MeaVZcqfh2lc0u4Zn8QNrp7Qo3n5RWQ=
-github.com/onflow/flow-go v0.31.1-0.20230606220911-189f62e4bc4d/go.mod h1:nQlTMCoCS4jluJQAtFfNUGHn2WgfiAD0u2emJWG8NBU=
+github.com/onflow/flow-go v0.31.1-0.20230606232908-66e59a929e3d h1:Ra+6rVA4vxbeSl/R//B/3fLhshxDmXsuEZPI+DUsbmU=
+github.com/onflow/flow-go v0.31.1-0.20230606232908-66e59a929e3d/go.mod h1:nQlTMCoCS4jluJQAtFfNUGHn2WgfiAD0u2emJWG8NBU=
 github.com/onflow/flow-go-sdk v0.24.0/go.mod h1:IoptMLPyFXWvyd9yYA6/4EmSeeozl6nJoIv4FaEMg74=
 github.com/onflow/flow-go-sdk v0.41.1 h1:VXT5TvA+WmpedOcbkXu+65wq+N+j5Yu3VvxCDqLoc3U=
 github.com/onflow/flow-go-sdk v0.41.1/go.mod h1:tiGY/eGgk3/aeeJ5DBu2AeaJfoqI9o1S614dLrIl4Js=

--- a/go.sum
+++ b/go.sum
@@ -699,11 +699,11 @@ github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3 h1:X25A1dNajNUtE+K
 github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3/go.mod h1:dqAUVWwg+NlOhsuBHex7bEWmsUjsiExzhe/+t4xNH6A=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.0 h1:XEKE6qJUw3luhsYmIOteXP53gtxNxrwTohgxJXCYqBE=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.0/go.mod h1:kTMFIySzEJJeupk+7EmXs0EJ6CBWY/MV9fv9iYQk+RU=
-github.com/onflow/flow-go v0.30.1-0.20230606183951-596485936163 h1:NBUlP5KItRxIzVEJwQiVagxcH2LmJ9ajnojge6E9FPY=
-github.com/onflow/flow-go v0.30.1-0.20230606183951-596485936163/go.mod h1:xeCRyj/Lk4fqa7ilw9H+Rjcf6Tv+nnSK3g1W83hrTyw=
+github.com/onflow/flow-go v0.31.1-0.20230606220911-189f62e4bc4d h1:2owezgewMpB2MeaVZcqfh2lc0u4Zn8QNrp7Qo3n5RWQ=
+github.com/onflow/flow-go v0.31.1-0.20230606220911-189f62e4bc4d/go.mod h1:nQlTMCoCS4jluJQAtFfNUGHn2WgfiAD0u2emJWG8NBU=
 github.com/onflow/flow-go-sdk v0.24.0/go.mod h1:IoptMLPyFXWvyd9yYA6/4EmSeeozl6nJoIv4FaEMg74=
-github.com/onflow/flow-go-sdk v0.41.0 h1:wYIlw5wa1G7/Gtc/DnNMgcTiWwgETEvo416iB5bXTKc=
-github.com/onflow/flow-go-sdk v0.41.0/go.mod h1:rxVy5gA4pUEoRYiSrXMzHRyfjQ/4Zqoz4cjEWT24j5c=
+github.com/onflow/flow-go-sdk v0.41.1 h1:VXT5TvA+WmpedOcbkXu+65wq+N+j5Yu3VvxCDqLoc3U=
+github.com/onflow/flow-go-sdk v0.41.1/go.mod h1:tiGY/eGgk3/aeeJ5DBu2AeaJfoqI9o1S614dLrIl4Js=
 github.com/onflow/flow-go/crypto v0.21.3/go.mod h1:vI6V4CY3R6c4JKBxdcRiR/AnjBfL8OSD97bJc60cLuQ=
 github.com/onflow/flow-go/crypto v0.24.7 h1:RCLuB83At4z5wkAyUCF7MYEnPoIIOHghJaODuJyEoW0=
 github.com/onflow/flow-go/crypto v0.24.7/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7Q6u+bCI78lfNX0=

--- a/storage/remote/store_test.go
+++ b/storage/remote/store_test.go
@@ -25,8 +25,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/onflow/flow-emulator/adapters"
 	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-emulator/adapters"
 
 	"github.com/onflow/flow-archive/api/archive"
 	"github.com/onflow/flow-archive/codec/zbor"
@@ -189,17 +190,17 @@ func Test_SimulatedMainnetTransaction(t *testing.T) {
 		SetPayer(addr)
 
 	err = adapter.SendTransaction(context.Background(), *tx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	txRes, err := b.ExecuteNextTransaction()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = b.CommitBlock()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NoError(t, err)
 	assert.NoError(t, txRes.Error)
-	assert.Len(t, txRes.Events, 1)
+
+	require.Len(t, txRes.Events, 1)
 	assert.Equal(t, txRes.Events[0].String(), "A.9799f28ff0453528.Ping.PingEmitted: 0x953f6f26d61710cb0e140bfde1022483b9ef410ddd181bac287d9968c84f4778")
 	assert.Equal(t, txRes.Events[0].Value.String(), `A.9799f28ff0453528.Ping.PingEmitted(sound: "ping ping ping")`)
 }
@@ -240,14 +241,14 @@ func Test_SimulatedMainnetTransactionWithChanges(t *testing.T) {
 		SetPayer(addr)
 
 	err = adapter.SendTransaction(context.Background(), *tx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	txRes, err := b.ExecuteNextTransaction()
-	assert.NoError(t, err)
-	assert.NoError(t, txRes.Error)
+	require.NoError(t, err)
+	require.NoError(t, txRes.Error)
 
 	_, err = b.CommitBlock()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	script = []byte(`
 		import Ping from 0x9799f28ff0453528
@@ -265,17 +266,17 @@ func Test_SimulatedMainnetTransactionWithChanges(t *testing.T) {
 		SetPayer(addr)
 
 	err = adapter.SendTransaction(context.Background(), *tx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	txRes, err = b.ExecuteNextTransaction()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = b.CommitBlock()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NoError(t, err)
 	assert.NoError(t, txRes.Error)
-	assert.Len(t, txRes.Events, 1)
+
+	require.Len(t, txRes.Events, 1)
 	assert.Equal(t, txRes.Events[0].String(), "A.9799f28ff0453528.Ping.PingEmitted: 0x953f6f26d61710cb0e140bfde1022483b9ef410ddd181bac287d9968c84f4778")
 	assert.Equal(t, txRes.Events[0].Value.String(), `A.9799f28ff0453528.Ping.PingEmitted(sound: "pong pong pong")`)
 }


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v0.39.2](https://github.com/onflow/cadence/releases/tag/v0.39.2)
- [onflow/flow-go-sdk v0.41.1](https://github.com/onflow/flow-go-sdk/releases/tag/v0.41.1)
- [onflow/flow-go 189f62e](https://github.com/onflow/flow-go/releases/tag/189f62e)

