### PR TITLE
Update to Cadence v0.39.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,10 +13,10 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v0.39.2
+	github.com/onflow/cadence v0.39.3
 	github.com/onflow/flow-archive v1.3.4-0.20230503192214-9e81e82d4dcc
-	github.com/onflow/flow-go v0.31.1-0.20230606232908-66e59a929e3d
-	github.com/onflow/flow-go-sdk v0.41.1
+	github.com/onflow/flow-go v0.31.1-0.20230607185125-e75265a6c631
+	github.com/onflow/flow-go-sdk v0.41.2
 	github.com/onflow/flow-go/crypto v0.24.7
 	github.com/onflow/flow-nft/lib/go/contracts v0.0.0-20220727161549-d59b1e547ac4
 	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230602212908-08fc6536d391

--- a/go.sum
+++ b/go.sum
@@ -689,8 +689,8 @@ github.com/onflow/atree v0.1.0-beta1.0.20211027184039-559ee654ece9/go.mod h1:+6x
 github.com/onflow/atree v0.6.0 h1:j7nQ2r8npznx4NX39zPpBYHmdy45f4xwoi+dm37Jk7c=
 github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVFi0tc=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.39.2 h1:GfLsLx1O93xAKdItdiy3bWb9OfQXK1z9KFAzZ05smns=
-github.com/onflow/cadence v0.39.2/go.mod h1:OIJLyVBPa339DCBQXBfGaorT4tBjQh9gSKe+ZAIyyh0=
+github.com/onflow/cadence v0.39.3 h1:bptR6yS9O7zxOn1doja1VjLQFfx7dFcGuO49UPs72YU=
+github.com/onflow/cadence v0.39.3/go.mod h1:OIJLyVBPa339DCBQXBfGaorT4tBjQh9gSKe+ZAIyyh0=
 github.com/onflow/flow-archive v1.3.4-0.20230503192214-9e81e82d4dcc h1:C4ZniFeOv+pHlDLJdGc/4e3NklSjVuvaXKN47980gnY=
 github.com/onflow/flow-archive v1.3.4-0.20230503192214-9e81e82d4dcc/go.mod h1:UPsvKk/37Atosif4wlBl3gsLbGJyGpdXYpXDsWtMVBE=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.3 h1:wV+gcgOY0oJK4HLZQYQoK+mm09rW1XSxf83yqJwj0n4=
@@ -699,11 +699,11 @@ github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3 h1:X25A1dNajNUtE+K
 github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3/go.mod h1:dqAUVWwg+NlOhsuBHex7bEWmsUjsiExzhe/+t4xNH6A=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.0 h1:XEKE6qJUw3luhsYmIOteXP53gtxNxrwTohgxJXCYqBE=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.0/go.mod h1:kTMFIySzEJJeupk+7EmXs0EJ6CBWY/MV9fv9iYQk+RU=
-github.com/onflow/flow-go v0.31.1-0.20230606232908-66e59a929e3d h1:Ra+6rVA4vxbeSl/R//B/3fLhshxDmXsuEZPI+DUsbmU=
-github.com/onflow/flow-go v0.31.1-0.20230606232908-66e59a929e3d/go.mod h1:nQlTMCoCS4jluJQAtFfNUGHn2WgfiAD0u2emJWG8NBU=
+github.com/onflow/flow-go v0.31.1-0.20230607185125-e75265a6c631 h1:O6f/c9y3j0N6/u2anzDZKtdoGolzV2LJ0Xcg0vO4ElY=
+github.com/onflow/flow-go v0.31.1-0.20230607185125-e75265a6c631/go.mod h1:ZKfmlbs+X3t+5cURDllEA7j+/O79yNG0c6z7LkxGVi8=
 github.com/onflow/flow-go-sdk v0.24.0/go.mod h1:IoptMLPyFXWvyd9yYA6/4EmSeeozl6nJoIv4FaEMg74=
-github.com/onflow/flow-go-sdk v0.41.1 h1:VXT5TvA+WmpedOcbkXu+65wq+N+j5Yu3VvxCDqLoc3U=
-github.com/onflow/flow-go-sdk v0.41.1/go.mod h1:tiGY/eGgk3/aeeJ5DBu2AeaJfoqI9o1S614dLrIl4Js=
+github.com/onflow/flow-go-sdk v0.41.2 h1:O/yjdS0V+NHgg98QeVWQt2aDJ+m3znGgBOPy/PfrhXo=
+github.com/onflow/flow-go-sdk v0.41.2/go.mod h1:SJ2oAvz3FHCyNfDw7XojmIxsduVFyL7dAgp+W1LnW8M=
 github.com/onflow/flow-go/crypto v0.21.3/go.mod h1:vI6V4CY3R6c4JKBxdcRiR/AnjBfL8OSD97bJc60cLuQ=
 github.com/onflow/flow-go/crypto v0.24.7 h1:RCLuB83At4z5wkAyUCF7MYEnPoIIOHghJaODuJyEoW0=
 github.com/onflow/flow-go/crypto v0.24.7/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7Q6u+bCI78lfNX0=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v0.39.3](https://github.com/onflow/cadence/releases/tag/v0.39.3)
- [onflow/flow-go-sdk v0.41.2](https://github.com/onflow/flow-go-sdk/releases/tag/v0.41.2)
- [onflow/flow-go e75265a](https://github.com/onflow/flow-go/releases/tag/e75265a)

