### PR TITLE
Add tests for latest regressions

### DIFF
--- a/emulator/contracts_test.go
+++ b/emulator/contracts_test.go
@@ -1,0 +1,60 @@
+package emulator_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/flow-emulator/emulator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommonContractsDeployment(t *testing.T) {
+
+	t.Parallel()
+
+	b, err := emulator.New(
+		emulator.Contracts(emulator.CommonContracts),
+	)
+	require.NoError(t, err)
+
+	serviceAccount := b.ServiceKey().Address.Hex()
+	scriptCode := fmt.Sprintf(`
+	    import
+	        FUSD,
+	        NonFungibleToken,
+	        MetadataViews,
+	        ExampleNFT,
+	        NFTStorefrontV2,
+	        NFTStorefront
+	    from 0x%s
+
+	    pub fun main(): Bool {
+	        log(Type<FUSD>().identifier)
+	        log(Type<NonFungibleToken>().identifier)
+	        log(Type<MetadataViews>().identifier)
+	        log(Type<ExampleNFT>().identifier)
+	        log(Type<NFTStorefrontV2>().identifier)
+	        log(Type<NFTStorefront>().identifier)
+
+	        return true
+	    }
+	`, serviceAccount)
+
+	scriptResult, err := b.ExecuteScript([]byte(scriptCode), [][]byte{})
+	require.NoError(t, err)
+	assert.ElementsMatch(
+		t,
+		[]string{
+			"\"A.f8d6e0586b0a20c7.FUSD\"",
+			"\"A.f8d6e0586b0a20c7.NonFungibleToken\"",
+			"\"A.f8d6e0586b0a20c7.MetadataViews\"",
+			"\"A.f8d6e0586b0a20c7.ExampleNFT\"",
+			"\"A.f8d6e0586b0a20c7.NFTStorefrontV2\"",
+			"\"A.f8d6e0586b0a20c7.NFTStorefront\"",
+		},
+		scriptResult.Logs,
+	)
+	assert.Equal(t, cadence.NewBool(true), scriptResult.Value)
+}

--- a/emulator/coverage_report_test.go
+++ b/emulator/coverage_report_test.go
@@ -1,0 +1,81 @@
+package emulator_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/flow-emulator/adapters"
+	"github.com/onflow/flow-emulator/emulator"
+	flowsdk "github.com/onflow/flow-go-sdk"
+	flowgo "github.com/onflow/flow-go/model/flow"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoverageReport(t *testing.T) {
+
+	t.Parallel()
+
+	coverageReport := runtime.NewCoverageReport()
+	b, err := emulator.New(
+		emulator.WithCoverageReport(coverageReport),
+	)
+	require.NoError(t, err)
+
+	coverageReport.Reset()
+	logger := zerolog.Nop()
+	adapter := adapters.NewSDKAdapter(&logger, b)
+
+	addTwoScript, counterAddress := DeployAndGenerateAddTwoScript(t, adapter)
+
+	tx := flowsdk.NewTransaction().
+		SetScript([]byte(addTwoScript)).
+		SetGasLimit(flowgo.DefaultMaxTransactionGasLimit).
+		SetProposalKey(b.ServiceKey().Address, b.ServiceKey().Index, b.ServiceKey().SequenceNumber).
+		SetPayer(b.ServiceKey().Address).
+		AddAuthorizer(b.ServiceKey().Address)
+
+	signer, err := b.ServiceKey().Signer()
+	require.NoError(t, err)
+
+	err = tx.SignEnvelope(b.ServiceKey().Address, b.ServiceKey().Index, signer)
+	require.NoError(t, err)
+
+	callScript := GenerateGetCounterCountScript(counterAddress, b.ServiceKey().Address)
+
+	// Sample call (value is 0)
+	scriptResult, err := b.ExecuteScript([]byte(callScript), nil)
+	require.NoError(t, err)
+	assert.Equal(t, cadence.NewInt(0), scriptResult.Value)
+
+	// Submit tx (script adds 2)
+	err = adapter.SendTransaction(context.Background(), *tx)
+	require.NoError(t, err)
+
+	txResult, err := b.ExecuteNextTransaction()
+	require.NoError(t, err)
+	AssertTransactionSucceeded(t, txResult)
+
+	address, err := common.HexToAddress("0x01cf0e2f2f715450")
+	require.NoError(t, err)
+	location := common.AddressLocation{
+		Address: address,
+		Name:    "Counting",
+	}
+	coverage := coverageReport.Coverage[location]
+
+	assert.Equal(t, []int{}, coverage.MissedLines())
+	assert.Equal(t, 4, coverage.Statements)
+	assert.Equal(t, "100.0%", coverage.Percentage())
+	assert.EqualValues(
+		t,
+		map[int]int{
+			11: 1, 15: 1, 16: 1, 21: 1,
+		},
+		coverage.LineHits,
+	)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -305,7 +305,7 @@ func (s *EmulatorServer) Stop() {
 
 func configureStorage(conf *Config) (storageProvider storage.Store, err error) {
 
-	if conf.ChainID != flowgo.Emulator {
+	if conf.ChainID == flowgo.Testnet || conf.ChainID == flowgo.Mainnet {
 		storageProvider, err = remote.New(remote.WithChainID(conf.ChainID))
 		if err != nil {
 			return nil, err

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -97,12 +97,12 @@ func TestCustomChainID(t *testing.T) {
 
 	conf := &Config{
 		WithContracts: true,
-		ChainID:       "flow-mainnet",
+		ChainID:       "flow-sandboxnet",
 	}
 	logger := zerolog.Nop()
 	server := NewEmulatorServer(&logger, conf)
 
 	serviceAccount := server.Emulator().ServiceKey().Address.Hex()
 
-	require.Equal(t, serviceAccount, "e467b9dd11fa00df")
+	require.Equal(t, "f4527793ee68aede", serviceAccount)
 }


### PR DESCRIPTION
## Description

Add two test cases to account for the regressions that were fixed in https://github.com/onflow/flow-emulator/pull/398.
- Tests for coverage reporting
- Tests for deployment of common contracts
- Update `TestCustomChainID` so that it does not connect to the `mainnet` archive node [1]


[1] This test case is flaky, since it actually connects to `archive.mainnet.nodes.onflow.org:9000`. It failed some times, because it was unable to connect to that host. The storage provider for the `mainnet` `ChainID` is the following:
```go
Storage Provider:  &{0xc0001a8e00 0xc00007e910 0xc0001d8a80 archive.mainnet.nodes.onflow.org:9000}
```
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
