### PR TITLE
Update to Cadence 0.39.8 and use CCF events mode to fix field order compatibility

### DIFF
--- a/adapters/access_test.go
+++ b/adapters/access_test.go
@@ -747,7 +747,7 @@ func TestAccess(t *testing.T) {
 func ccfEventFixture(t *testing.T) flowgo.Event {
 	cadenceValue, err := cadence.NewValue(2)
 	require.NoError(t, err)
-	ccfEvent, err := ccf.Encode(cadenceValue)
+	ccfEvent, err := ccf.EventsEncMode.Encode(cadenceValue)
 	require.NoError(t, err)
 	return flowgo.Event{
 		Payload: ccfEvent,

--- a/convert/flow.go
+++ b/convert/flow.go
@@ -184,7 +184,7 @@ func FlowTransactionResultToSDK(result *access.TransactionResult) (*sdk.Transact
 }
 
 func SDKEventToFlow(event sdk.Event) (flowgo.Event, error) {
-	payload, err := ccf.Encode(event.Value)
+	payload, err := ccf.EventsEncMode.Encode(event.Value)
 	if err != nil {
 		return flowgo.Event{}, err
 	}
@@ -199,7 +199,7 @@ func SDKEventToFlow(event sdk.Event) (flowgo.Event, error) {
 }
 
 func FlowEventToSDK(flowEvent flowgo.Event) (sdk.Event, error) {
-	cadenceValue, err := ccf.Decode(nil, flowEvent.Payload)
+	cadenceValue, err := ccf.EventsDecMode.Decode(nil, flowEvent.Payload)
 	if err != nil {
 		return sdk.Event{}, err
 	}

--- a/emulator/accountlinking_test.go
+++ b/emulator/accountlinking_test.go
@@ -100,6 +100,8 @@ func TestAccountLinking(t *testing.T) {
 
 	actualEvent := events[0].Events[0]
 	decodedEvent := actualEvent.Value
+	decodedEventType := decodedEvent.Type().(*cadence.EventType)
+
 	expectedID := flowsdk.Event{
 		TransactionID: tx.ID(),
 		EventIndex:    0,
@@ -110,6 +112,9 @@ func TestAccountLinking(t *testing.T) {
 	expectedPath, err := cadence.NewPath(common.PathDomainPrivate, "foo")
 	require.NoError(t, err)
 	require.Len(t, decodedEvent.Fields, 2)
-	assert.Equal(t, expectedPath, decodedEvent.Fields[0])
-	assert.Equal(t, cadence.NewAddress(serviceAccountAddress), decodedEvent.Fields[1])
+	require.Len(t, decodedEventType.Fields, 2)
+	assert.Equal(t, "address", decodedEventType.Fields[0].Identifier)
+	assert.Equal(t, cadence.NewAddress(serviceAccountAddress), decodedEvent.Fields[0])
+	assert.Equal(t, "path", decodedEventType.Fields[1].Identifier)
+	assert.Equal(t, expectedPath, decodedEvent.Fields[1])
 }

--- a/emulator/events_test.go
+++ b/emulator/events_test.go
@@ -127,11 +127,14 @@ func TestEventEmitted(t *testing.T) {
 
 		actualEvent := events[0].Events[0]
 		decodedEvent := actualEvent.Value
+		decodedEventType := decodedEvent.Type().(*cadence.EventType)
 		expectedID := flowsdk.Event{TransactionID: tx.ID(), EventIndex: 0}.ID()
 
 		assert.Equal(t, string(expectedType), actualEvent.Type)
 		assert.Equal(t, expectedID, actualEvent.ID())
+		assert.Equal(t, "x", decodedEventType.Fields[0].Identifier)
 		assert.Equal(t, cadence.NewInt(1), decodedEvent.Fields[0])
+		assert.Equal(t, "y", decodedEventType.Fields[1].Identifier)
 		assert.Equal(t, cadence.NewInt(2), decodedEvent.Fields[1])
 
 		events, err = adapter.GetEventsForBlockIDs(context.Background(), string(expectedType), []flowsdk.Identifier{flowsdk.Identifier(block.Header.ID())})
@@ -140,11 +143,14 @@ func TestEventEmitted(t *testing.T) {
 
 		actualEvent = events[0].Events[0]
 		decodedEvent = actualEvent.Value
+		decodedEventType = decodedEvent.Type().(*cadence.EventType)
 		expectedID = flowsdk.Event{TransactionID: tx.ID(), EventIndex: 0}.ID()
 
 		assert.Equal(t, string(expectedType), actualEvent.Type)
 		assert.Equal(t, expectedID, actualEvent.ID())
+		assert.Equal(t, "x", decodedEventType.Fields[0].Identifier)
 		assert.Equal(t, cadence.NewInt(1), decodedEvent.Fields[0])
+		assert.Equal(t, "y", decodedEventType.Fields[1].Identifier)
 		assert.Equal(t, cadence.NewInt(2), decodedEvent.Fields[1])
 
 	})

--- a/emulator/transaction_test.go
+++ b/emulator/transaction_test.go
@@ -1439,6 +1439,7 @@ func TestGetTransactionResult(t *testing.T) {
 	assert.Equal(t, tx.ID(), event.TransactionID)
 	assert.Equal(t, string(eventType), event.Type)
 	assert.Equal(t, 0, event.EventIndex)
+	assert.Equal(t, 1, len(event.Value.Fields))
 	assert.Equal(t, cadence.NewInt(2), event.Value.Fields[0])
 }
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v0.39.3
+	github.com/onflow/cadence v0.39.8
 	github.com/onflow/flow-archive v1.3.4-0.20230503192214-9e81e82d4dcc
 	github.com/onflow/flow-go v0.31.1-0.20230607185125-e75265a6c631
 	github.com/onflow/flow-go-sdk v0.41.2

--- a/go.sum
+++ b/go.sum
@@ -689,8 +689,8 @@ github.com/onflow/atree v0.1.0-beta1.0.20211027184039-559ee654ece9/go.mod h1:+6x
 github.com/onflow/atree v0.6.0 h1:j7nQ2r8npznx4NX39zPpBYHmdy45f4xwoi+dm37Jk7c=
 github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVFi0tc=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.39.3 h1:bptR6yS9O7zxOn1doja1VjLQFfx7dFcGuO49UPs72YU=
-github.com/onflow/cadence v0.39.3/go.mod h1:OIJLyVBPa339DCBQXBfGaorT4tBjQh9gSKe+ZAIyyh0=
+github.com/onflow/cadence v0.39.8 h1:qc6ZT66nSdcmtDaTRVcKi46pqZv8xaeXxlVDR4nfa0k=
+github.com/onflow/cadence v0.39.8/go.mod h1:OIJLyVBPa339DCBQXBfGaorT4tBjQh9gSKe+ZAIyyh0=
 github.com/onflow/flow-archive v1.3.4-0.20230503192214-9e81e82d4dcc h1:C4ZniFeOv+pHlDLJdGc/4e3NklSjVuvaXKN47980gnY=
 github.com/onflow/flow-archive v1.3.4-0.20230503192214-9e81e82d4dcc/go.mod h1:UPsvKk/37Atosif4wlBl3gsLbGJyGpdXYpXDsWtMVBE=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.3 h1:wV+gcgOY0oJK4HLZQYQoK+mm09rW1XSxf83yqJwj0n4=


### PR DESCRIPTION
Updates https://github.com/onflow/cadence/issues/2283

## Description

Use presets for events and don't sort fields anymore for events because some programs were accessing Cadence fields by index (dependency on sequence of fields).

Use events encoding and decoding mode created at startup instead of default encoding/decoding.  For example:
- `ccf.EventsEncMode.Encode()`
- `ccf.EventsDecMode.Decode()`

Updated default settings used by `ccf.Encode()` and `ccf.Decode()` use same presets as events mode (no longer sort fields), but defaults should only be used for development.

Each CCF-based protocol should use its own distinct mode which helps document each protocol and reduces risk of unintentionally breaking compatibility.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
