### PR TITLE
Implement GetTransaction*ByBlockID

### DIFF
--- a/adapters/access.go
+++ b/adapters/access.go
@@ -21,6 +21,7 @@ package adapters
 import (
 	"context"
 	"fmt"
+
 	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/flow-emulator/emulator"
 	"github.com/onflow/flow-emulator/types"
@@ -395,7 +396,7 @@ func (a *AccessAdapter) GetTransactionResultByIndex(_ context.Context, blockID f
 	if err != nil {
 		return nil, convertError(err)
 	}
-	if len(results) < int(index) {
+	if len(results) <= int(index) {
 		return nil, convertError(&types.TransactionNotFoundError{ID: flowgo.Identifier{}})
 	}
 


### PR DESCRIPTION
## Description

This PR makes a few improvements to the emulator's access API implemention:

1. Implements `GetTransactionsByBlockID` and `GetTransactionResultsByBlockID`
2. Fixes an off-by-one error in `GetTransactionByIndex`
3. Cleans up locking to be more consistent in `blockchain.go`

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
