### PR TITLE
Change log-level for blockchain logs to debug

### DIFF
--- a/emulator/blockchain.go
+++ b/emulator/blockchain.go
@@ -1376,7 +1376,7 @@ func (b *Blockchain) executeAndCommitBlock() (*flowgo.Block, []*types.Transactio
 	}
 
 	blockID := block.ID()
-	b.conf.ServerLogger.Info().Fields(map[string]any{
+	b.conf.ServerLogger.Debug().Fields(map[string]any{
 		"blockHeight": block.Header.Height,
 		"blockID":     hex.EncodeToString(blockID[:]),
 	}).Msgf("📦 Block #%d committed", block.Header.Height)

--- a/utils/logging.go
+++ b/utils/logging.go
@@ -20,6 +20,7 @@ package utils
 
 import (
 	"fmt"
+
 	"github.com/logrusorgru/aurora"
 	"github.com/onflow/flow-emulator/types"
 	sdk "github.com/onflow/flow-go-sdk"
@@ -28,7 +29,7 @@ import (
 
 func PrintScriptResult(logger *zerolog.Logger, result *types.ScriptResult) {
 	if result.Succeeded() {
-		logger.Info().
+		logger.Debug().
 			Str("scriptID", result.ScriptID.String()).
 			Uint64("computationUsed", result.ComputationUsed).
 			Msg("⭐  Script executed")
@@ -37,14 +38,6 @@ func PrintScriptResult(logger *zerolog.Logger, result *types.ScriptResult) {
 			Str("scriptID", result.ScriptID.String()).
 			Uint64("computationUsed", result.ComputationUsed).
 			Msg("❗  Script reverted")
-	}
-
-	for _, log := range result.Logs {
-		logger.Debug().Msgf(
-			"%s %s",
-			logPrefix("LOG", result.ScriptID, aurora.BlueFg),
-			log,
-		)
 	}
 
 	if !result.Succeeded() {
@@ -58,7 +51,7 @@ func PrintScriptResult(logger *zerolog.Logger, result *types.ScriptResult) {
 
 func PrintTransactionResult(logger *zerolog.Logger, result *types.TransactionResult) {
 	if result.Succeeded() {
-		logger.Info().
+		logger.Debug().
 			Str("txID", result.TransactionID.String()).
 			Uint64("computationUsed", result.ComputationUsed).
 			Msg("⭐  Transaction executed")
@@ -67,14 +60,6 @@ func PrintTransactionResult(logger *zerolog.Logger, result *types.TransactionRes
 			Str("txID", result.TransactionID.String()).
 			Uint64("computationUsed", result.ComputationUsed).
 			Msg("❗  Transaction reverted")
-	}
-
-	for _, log := range result.Logs {
-		logger.Info().Msgf(
-			"%s %s",
-			logPrefix("LOG", result.TransactionID, aurora.BlueFg),
-			log,
-		)
 	}
 
 	for _, event := range result.Events {


### PR DESCRIPTION
## Description

Blockchain logs should be printed to the console, only when the emulator server is started with the `--verbose` flag, e.g.
```bash
flow emulator --verbose --storage-limit=false
```
and the log-level should be `zerolog.DebugLevel`.
This allows 3rd-party tools that use the emulator as a library, to differentiate the Cadence logs, which are printed with a `zerolog.InfoLevel`. See regression in https://github.com/onflow/cadence-tools/actions/runs/5350895526/jobs/9704076572?pr=152

Also do not log `ScriptResult.Logs` & `TransactionResult.Logs`, as they are already logged by the `CadenceHook` (see [here](https://github.com/onflow/flow-emulator/blob/master/emulator/blockchain.go#L493-L511))

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
