### PR TITLE
Introduce a settable `Clock` for `Blockchain` and `PendingBlock`

### DIFF
--- a/emulator/clock.go
+++ b/emulator/clock.go
@@ -1,0 +1,35 @@
+/*
+ * Flow Emulator
+ *
+ * Copyright 2019 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package emulator
+
+import "time"
+
+type Clock interface {
+	Now() time.Time
+}
+
+type SystemClock struct{}
+
+func (sc SystemClock) Now() time.Time {
+	return time.Now().UTC()
+}
+
+func NewSystemClock() SystemClock {
+	return SystemClock{}
+}

--- a/emulator/pendingBlock.go
+++ b/emulator/pendingBlock.go
@@ -24,6 +24,7 @@ type pendingBlock struct {
 	height    uint64
 	view      uint64
 	parentID  flowgo.Identifier
+	clock     Clock
 	timestamp time.Time
 	// mapping from transaction ID to transaction
 	transactions map[flowgo.Identifier]*flowgo.TransactionBody
@@ -43,15 +44,16 @@ type pendingBlock struct {
 func newPendingBlock(
 	prevBlock *flowgo.Block,
 	ledgerSnapshot snapshot.StorageSnapshot,
+	clock Clock,
 ) *pendingBlock {
-
 	return &pendingBlock{
 		height: prevBlock.Header.Height + 1,
 		// the view increments by between 1 and MaxViewIncrease to match
 		// behaviour on a real network, where views are not consecutive
 		view:               prevBlock.Header.View + uint64(rand.Intn(MaxViewIncrease)+1),
 		parentID:           prevBlock.ID(),
-		timestamp:          time.Now().UTC(),
+		clock:              clock,
+		timestamp:          clock.Now(),
 		transactions:       make(map[flowgo.Identifier]*flowgo.TransactionBody),
 		transactionIDs:     make([]flowgo.Identifier, 0),
 		transactionResults: make(map[flowgo.Identifier]IndexedTransactionResult),
@@ -212,4 +214,12 @@ func (b *pendingBlock) Size() int {
 // Empty returns true if the pending block is empty.
 func (b *pendingBlock) Empty() bool {
 	return b.Size() == 0
+}
+
+// SetClock sets the given clock on the pending block.
+// After this block is committed, the block timestamp will
+// contain the value of clock.Now().
+func (b *pendingBlock) SetClock(clock Clock) {
+	b.clock = clock
+	b.timestamp = clock.Now()
 }

--- a/emulator/pendingBlock_test.go
+++ b/emulator/pendingBlock_test.go
@@ -2,7 +2,9 @@ package emulator_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/onflow/flow-emulator/adapters"
 	"github.com/onflow/flow-emulator/emulator"
@@ -379,4 +381,61 @@ func TestPendingBlockCommit(t *testing.T) {
 		assert.Equal(t, blockID, block.ID())
 		assert.Len(t, results, 1)
 	})
+}
+
+type testClock struct {
+	Time time.Time
+}
+
+func (tc testClock) Now() time.Time {
+	return tc.Time.UTC()
+}
+
+func TestPendingBlockSetTimestamp(t *testing.T) {
+
+	t.Parallel()
+
+	b, adapter, _, _, _ := setupPendingBlockTests(t)
+	clock := testClock{
+		Time: time.Now().UTC(),
+	}
+	b.SetClock(clock)
+	_, _ = b.CommitBlock()
+
+	script := []byte(`
+	    pub fun main(): UFix64 {
+	        return getCurrentBlock().timestamp
+	    }
+	`)
+	scriptResult, err := adapter.ExecuteScriptAtLatestBlock(
+		context.Background(),
+		script,
+		[][]byte{},
+	)
+	require.NoError(t, err)
+
+	expected := fmt.Sprintf(
+		"{\"value\":\"%d.00000000\",\"type\":\"UFix64\"}\n",
+		clock.Time.Unix(),
+	)
+	assert.Equal(t, expected, string(scriptResult))
+
+	clock = testClock{
+		Time: time.Now().Add(time.Hour * 24 * 7).UTC(),
+	}
+	b.SetClock(clock)
+	_, _ = b.CommitBlock()
+
+	scriptResult, err = adapter.ExecuteScriptAtLatestBlock(
+		context.Background(),
+		script,
+		[][]byte{},
+	)
+	require.NoError(t, err)
+
+	expected = fmt.Sprintf(
+		"{\"value\":\"%d.00000000\",\"type\":\"UFix64\"}\n",
+		clock.Time.Unix(),
+	)
+	assert.Equal(t, expected, string(scriptResult))
 }


### PR DESCRIPTION
## Description

Currently, [to measure time in Cadence](https://developers.flow.com/cadence/measuring-time), developers can use something like the following:

```cadence
getCurrentBlock().timestamp
```

Contracts can use the above value in certain conditions, such as unlocking tokens after a year.

To simulate/test scenarios with time expiration or generally passage of time, it would be useful to have the ability to set the blockchain's timestamp in the future or even the past. For example, this can be used and exposed in the Cadence Testing Framework, and in other tools that use the Emulator for integration tests.
 
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
