### PR TITLE
Docker Build Fix

### DIFF
--- a/cmd/emulator/Dockerfile
+++ b/cmd/emulator/Dockerfile
@@ -3,7 +3,7 @@
 # NOTE: Must be run in the context of the repo's root directory
 
 ## Build the app binary
-FROM --platform=$BUILDPLATFORM golang:1.18 AS build-app
+FROM --platform=$BUILDPLATFORM golang:1.19 AS build-app
 
 # Build the app binary in /app
 RUN mkdir /app


### PR DESCRIPTION


## Description

There is an issue with the CI that builds the emulator docker images:  https://github.com/onflow/flow-emulator/actions/runs/5575876555/jobs/10186429145#step:7:573

As far as I can see this will fix that problem.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
