### PR TITLE
Computation parity with FVM

### DIFF
--- a/emulator/script_test.go
+++ b/emulator/script_test.go
@@ -164,9 +164,9 @@ func TestInfiniteScript(t *testing.T) {
 	require.NoError(t, err)
 
 	const code = `
-	    pub fun main() {
-	        main()
-	    }
+		pub fun main() {
+			main()
+		}
 	`
 	result, err := b.ExecuteScript([]byte(code), nil)
 	require.NoError(t, err)
@@ -174,65 +174,55 @@ func TestInfiniteScript(t *testing.T) {
 	require.True(t, fvmerrors.IsComputationLimitExceededError(result.Error))
 }
 
-func TestScriptWithExceeedingComputationLimit(t *testing.T) {
+func TestScriptExecutionLimit(t *testing.T) {
 
 	t.Parallel()
 
-	const limit = 2000
-	b, err := emulator.New(
-		emulator.WithScriptGasLimit(limit),
-	)
-	require.NoError(t, err)
-
 	const code = `
-	    pub fun main() {
-	        var s: Int256 = 1024102410241024
-	        var i: Int256 = 0
-	        var a: Int256 = 7
-	        var b: Int256 = 5
-	        var c: Int256 = 2
+		pub fun main() {
+			var s: Int256 = 1024102410241024
+			var i: Int256 = 0
+			var a: Int256 = 7
+			var b: Int256 = 5
+			var c: Int256 = 2
 
-	        while i < 150000 {
-	            s = s * a
-	            s = s / b
-	            s = s / c
-	            i = i + 1
-	        }
-	    }
+			while i < 150000 {
+				s = s * a
+				s = s / b
+				s = s / c
+				i = i + 1
+			}
+		}
 	`
-	result, err := b.ExecuteScript([]byte(code), nil)
-	require.NoError(t, err)
 
-	require.True(t, fvmerrors.IsComputationLimitExceededError(result.Error))
-}
+	t.Run("ExceedingLimit", func(t *testing.T) {
 
-func TestScriptWithSufficientComputationLimit(t *testing.T) {
+		t.Parallel()
 
-	t.Parallel()
+		const limit = 2000
+		b, err := emulator.New(
+			emulator.WithScriptGasLimit(limit),
+		)
+		require.NoError(t, err)
 
-	const limit = 19000
-	b, err := emulator.New(
-		emulator.WithScriptGasLimit(limit),
-	)
-	require.NoError(t, err)
+		result, err := b.ExecuteScript([]byte(code), nil)
+		require.NoError(t, err)
 
-	const code = `
-	    pub fun main() {
-	        var s: Int256 = 1024102410241024
-	        var i: Int256 = 0
-	        var a: Int256 = 7
-	        var b: Int256 = 5
-	        var c: Int256 = 2
+		require.True(t, fvmerrors.IsComputationLimitExceededError(result.Error))
+	})
 
-	        while i < 150000 {
-	            s = s * a
-	            s = s / b
-	            s = s / c
-	            i = i + 1
-	        }
-	    }
-	`
-	result, err := b.ExecuteScript([]byte(code), nil)
-	require.NoError(t, err)
-	require.NoError(t, result.Error)
+	t.Run("SufficientLimit", func(t *testing.T) {
+
+		t.Parallel()
+
+		const limit = 19000
+		b, err := emulator.New(
+			emulator.WithScriptGasLimit(limit),
+		)
+		require.NoError(t, err)
+
+		result, err := b.ExecuteScript([]byte(code), nil)
+		require.NoError(t, err)
+		require.NoError(t, result.Error)
+	})
 }

--- a/emulator/script_test.go
+++ b/emulator/script_test.go
@@ -157,19 +157,82 @@ func TestInfiniteScript(t *testing.T) {
 
 	t.Parallel()
 
-	const limit = 1000
+	const limit = 90
 	b, err := emulator.New(
 		emulator.WithScriptGasLimit(limit),
 	)
 	require.NoError(t, err)
 
 	const code = `
-      pub fun main() {
-          main()
-      }
-    `
+	    pub fun main() {
+	        main()
+	    }
+	`
 	result, err := b.ExecuteScript([]byte(code), nil)
 	require.NoError(t, err)
 
 	require.True(t, fvmerrors.IsComputationLimitExceededError(result.Error))
+}
+
+func TestScriptWithExceeedingComputationLimit(t *testing.T) {
+
+	t.Parallel()
+
+	const limit = 2000
+	b, err := emulator.New(
+		emulator.WithScriptGasLimit(limit),
+	)
+	require.NoError(t, err)
+
+	const code = `
+	    pub fun main() {
+	        var s: Int256 = 1024102410241024
+	        var i: Int256 = 0
+	        var a: Int256 = 7
+	        var b: Int256 = 5
+	        var c: Int256 = 2
+
+	        while i < 150000 {
+	            s = s * a
+	            s = s / b
+	            s = s / c
+	            i = i + 1
+	        }
+	    }
+	`
+	result, err := b.ExecuteScript([]byte(code), nil)
+	require.NoError(t, err)
+
+	require.True(t, fvmerrors.IsComputationLimitExceededError(result.Error))
+}
+
+func TestScriptWithSufficientComputationLimit(t *testing.T) {
+
+	t.Parallel()
+
+	const limit = 19000
+	b, err := emulator.New(
+		emulator.WithScriptGasLimit(limit),
+	)
+	require.NoError(t, err)
+
+	const code = `
+	    pub fun main() {
+	        var s: Int256 = 1024102410241024
+	        var i: Int256 = 0
+	        var a: Int256 = 7
+	        var b: Int256 = 5
+	        var c: Int256 = 2
+
+	        while i < 150000 {
+	            s = s * a
+	            s = s / b
+	            s = s / c
+	            i = i + 1
+	        }
+	    }
+	`
+	result, err := b.ExecuteScript([]byte(code), nil)
+	require.NoError(t, err)
+	require.NoError(t, result.Error)
 }

--- a/emulator/transaction_test.go
+++ b/emulator/transaction_test.go
@@ -1765,7 +1765,7 @@ func TestInfiniteTransaction(t *testing.T) {
 
 	t.Parallel()
 
-	const limit = 1000
+	const limit = 90
 
 	b, adapter := setupTransactionTests(
 		t,
@@ -1774,16 +1774,16 @@ func TestInfiniteTransaction(t *testing.T) {
 	)
 
 	const code = `
-      pub fun test() {
-          test()
-      }
+	    pub fun test() {
+	        test()
+	    }
 
-      transaction {
-          execute {
-              test()
-          }
-      }
-    `
+	    transaction {
+	        execute {
+	            test()
+	        }
+	    }
+	`
 
 	// Create a new account
 
@@ -1814,6 +1814,129 @@ func TestInfiniteTransaction(t *testing.T) {
 	assert.NoError(t, err)
 
 	require.True(t, fvmerrors.IsComputationLimitExceededError(result.Error))
+}
+
+func TestTransactionWithExceedingComputationLimit(t *testing.T) {
+
+	t.Parallel()
+
+	const limit = 2000
+
+	b, adapter := setupTransactionTests(
+		t,
+		emulator.WithStorageLimitEnabled(false),
+		emulator.WithTransactionMaxGasLimit(limit),
+	)
+
+	const code = `
+	    transaction {
+	        execute {
+	            var s: Int256 = 1024102410241024
+	            var i: Int256 = 0
+	            var a: Int256 = 7
+	            var b: Int256 = 5
+	            var c: Int256 = 2
+
+	            while i < 150000 {
+	                s = s * a
+	                s = s / b
+	                s = s / c
+	                i = i + 1
+	            }
+	        }
+	    }
+	`
+
+	// Create a new account
+
+	accountKeys := test.AccountKeyGenerator()
+	accountKey, signer := accountKeys.NewWithSigner()
+	accountAddress, err := adapter.CreateAccount(context.Background(), []*flowsdk.AccountKey{accountKey}, nil)
+	assert.NoError(t, err)
+
+	// Sign the transaction using the new account.
+	// Do not test using the service account,
+	// as the computation limit is disabled for it
+
+	tx := flowsdk.NewTransaction().
+		SetScript([]byte(code)).
+		SetGasLimit(limit).
+		SetProposalKey(accountAddress, 0, 0).
+		SetPayer(accountAddress)
+
+	err = tx.SignEnvelope(accountAddress, 0, signer)
+	assert.NoError(t, err)
+
+	// Submit tx
+	err = adapter.SendTransaction(context.Background(), *tx)
+	assert.NoError(t, err)
+
+	// Execute tx
+	result, err := b.ExecuteNextTransaction()
+	assert.NoError(t, err)
+
+	require.True(t, fvmerrors.IsComputationLimitExceededError(result.Error))
+}
+
+func TestTransactionWithSufficientComputationLimit(t *testing.T) {
+
+	t.Parallel()
+
+	const limit = 19000
+
+	b, adapter := setupTransactionTests(
+		t,
+		emulator.WithStorageLimitEnabled(false),
+		emulator.WithTransactionMaxGasLimit(limit),
+	)
+
+	const code = `
+	    transaction {
+	        execute {
+	            var s: Int256 = 1024102410241024
+	            var i: Int256 = 0
+	            var a: Int256 = 7
+	            var b: Int256 = 5
+	            var c: Int256 = 2
+
+	            while i < 150000 {
+	                s = s * a
+	                s = s / b
+	                s = s / c
+	                i = i + 1
+	            }
+	        }
+	    }
+	`
+
+	// Create a new account
+
+	accountKeys := test.AccountKeyGenerator()
+	accountKey, signer := accountKeys.NewWithSigner()
+	accountAddress, err := adapter.CreateAccount(context.Background(), []*flowsdk.AccountKey{accountKey}, nil)
+	assert.NoError(t, err)
+
+	// Sign the transaction using the new account.
+	// Do not test using the service account,
+	// as the computation limit is disabled for it
+
+	tx := flowsdk.NewTransaction().
+		SetScript([]byte(code)).
+		SetGasLimit(limit).
+		SetProposalKey(accountAddress, 0, 0).
+		SetPayer(accountAddress)
+
+	err = tx.SignEnvelope(accountAddress, 0, signer)
+	assert.NoError(t, err)
+
+	// Submit tx
+	err = adapter.SendTransaction(context.Background(), *tx)
+	assert.NoError(t, err)
+
+	// Execute tx
+	result, err := b.ExecuteNextTransaction()
+	assert.NoError(t, err)
+	assert.NoError(t, result.Error)
 }
 
 func TestSubmitTransactionWithCustomLogger(t *testing.T) {

--- a/utils/logging.go
+++ b/utils/logging.go
@@ -32,11 +32,13 @@ func PrintScriptResult(logger *zerolog.Logger, result *types.ScriptResult) {
 		logger.Debug().
 			Str("scriptID", result.ScriptID.String()).
 			Uint64("computationUsed", result.ComputationUsed).
+			Uint64("memoryEstimate", result.MemoryEstimate).
 			Msg("⭐  Script executed")
 	} else {
 		logger.Warn().
 			Str("scriptID", result.ScriptID.String()).
 			Uint64("computationUsed", result.ComputationUsed).
+			Uint64("memoryEstimate", result.MemoryEstimate).
 			Msg("❗  Script reverted")
 	}
 
@@ -54,11 +56,13 @@ func PrintTransactionResult(logger *zerolog.Logger, result *types.TransactionRes
 		logger.Debug().
 			Str("txID", result.TransactionID.String()).
 			Uint64("computationUsed", result.ComputationUsed).
+			Uint64("memoryEstimate", result.MemoryEstimate).
 			Msg("⭐  Transaction executed")
 	} else {
 		logger.Warn().
 			Str("txID", result.TransactionID.String()).
 			Uint64("computationUsed", result.ComputationUsed).
+			Uint64("memoryEstimate", result.MemoryEstimate).
 			Msg("❗  Transaction reverted")
 	}
 


### PR DESCRIPTION
**Works towards:** https://github.com/onflow/developer-grants/issues/178

## Description

- Bring back display of `memoryEstimate` metric in logs (for scripts & transactions)
- Update computation and memory weights to achieve better parity with FVM
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
