### PR TITLE
Add additional contracts to startup logs

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -169,6 +169,9 @@ func NewEmulatorServer(logger *zerolog.Logger, conf *Config) *EmulatorServer {
 		"FungibleToken":      fvm.FungibleTokenAddress(chain).HexWithPrefix(),
 		"FlowFees":           environment.FlowFeesAddress(chain).HexWithPrefix(),
 		"FlowStorageFees":    chain.ServiceAddress().HexWithPrefix(),
+		"NonFungibleToken":   chain.ServiceAddress().HexWithPrefix(),
+		"ViewResolver":       chain.ServiceAddress().HexWithPrefix(),
+		"MetadataViews":      chain.ServiceAddress().HexWithPrefix(),
 	}
 	for contract, address := range coreContracts {
 		logger.Info().Fields(map[string]any{contract: address}).Msg("📜 Flow contract")


### PR DESCRIPTION


## Description

The contracts were [previously added](https://github.com/onflow/flow-emulator/pull/443), but I forgot to change the startup log.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
