### PR TITLE
Bring back comment for variable transaction fees

### DIFF
--- a/emulator/blockchain.go
+++ b/emulator/blockchain.go
@@ -715,6 +715,9 @@ func configureBootstrapProcedure(conf config, flowAccountKey flowgo.AccountPubli
 	options = append(options,
 		fvm.WithInitialTokenSupply(supply),
 		fvm.WithRestrictedAccountCreationEnabled(false),
+		// This enables variable transaction fees AND execution effort metering
+		// as described in Variable Transaction Fees:
+		// Execution Effort FLIP: https://github.com/onflow/flow/pull/753)
 		fvm.WithTransactionFee(fvm.DefaultTransactionFees),
 		fvm.WithExecutionMemoryLimit(math.MaxUint32),
 		fvm.WithExecutionMemoryWeights(meter.DefaultMemoryWeights),


### PR DESCRIPTION
## Description

Some comments were accidentally removed in https://github.com/onflow/flow-emulator/pull/451, this PR brings them back :innocent: 
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
