### PR TITLE
Fix rest metrics instantiation - auto update to onflow/cadence v0.40.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/psiemens/graceland v1.0.0
 	github.com/psiemens/sconfig v0.1.0
 	github.com/rs/zerolog v1.29.0
-	github.com/slok/go-http-metrics v0.10.0
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
@@ -126,6 +125,7 @@ require (
 	github.com/rs/cors v1.8.0 // indirect
 	github.com/schollz/progressbar/v3 v3.13.1 // indirect
 	github.com/sethvargo/go-retry v0.2.3 // indirect
+	github.com/slok/go-http-metrics v0.10.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect

--- a/server/access/rest.go
+++ b/server/access/rest.go
@@ -22,18 +22,20 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/onflow/flow-go/module"
 	"net"
 	"net/http"
 	"os"
 
-	"github.com/onflow/flow-emulator/adapters"
-	metricsProm "github.com/slok/go-http-metrics/metrics/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/engine/access/rest"
+	"github.com/onflow/flow-go/engine/access/rest/routes"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/metrics"
-	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-emulator/adapters"
 )
 
 type RestServer struct {
@@ -85,7 +87,11 @@ func NewRestServer(logger *zerolog.Logger, adapter *adapters.AccessAdapter, chai
 
 	// only collect metrics if not test
 	if flag.Lookup("test.v") == nil {
-		restCollector = metrics.NewRestCollector(metricsProm.Config{Prefix: "access_rest_api"})
+		var err error
+		restCollector, err = metrics.NewRestCollector(routes.URLToRoute, prometheus.DefaultRegisterer)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	srv, err := rest.NewServer(adapter, fmt.Sprintf("%s:3333", host), debugLogger, chain, restCollector)


### PR DESCRIPTION
## Description

Fixes issues with rest metrics initialization discovered by #461

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
