### PR TITLE
Allow configuration of blockchain's interpreter runtime

### DIFF
--- a/emulator/blockchain.go
+++ b/emulator/blockchain.go
@@ -548,7 +548,7 @@ func configureFVM(blockchain *Blockchain, conf config, blocks *blocks) (*fvm.Vir
 
 	cadenceLogger := conf.Logger.Hook(CadenceHook{MainLogger: &conf.ServerLogger}).Level(zerolog.DebugLevel)
 
-	config := runtime.Config{
+	runtimeConfig := runtime.Config{
 		Debugger:                     blockchain.debugger,
 		AccountLinkingEnabled:        true,
 		AttachmentsEnabled:           true,
@@ -556,13 +556,13 @@ func configureFVM(blockchain *Blockchain, conf config, blocks *blocks) (*fvm.Vir
 		CoverageReport:               conf.CoverageReport,
 	}
 	coverageReportedRuntime := &CoverageReportedRuntime{
-		Runtime:        runtime.NewInterpreterRuntime(config),
+		Runtime:        runtime.NewInterpreterRuntime(runtimeConfig),
 		CoverageReport: conf.CoverageReport,
-		Environment:    runtime.NewBaseInterpreterEnvironment(config),
+		Environment:    runtime.NewBaseInterpreterEnvironment(runtimeConfig),
 	}
 	customRuntimePool := reusableRuntime.NewCustomReusableCadenceRuntimePool(
 		1,
-		config,
+		runtimeConfig,
 		func(config runtime.Config) runtime.Runtime {
 			return coverageReportedRuntime
 		},


### PR DESCRIPTION
Work towards: https://github.com/onflow/cadence-tools/pull/210

## Description

Also expose a public method for creating script environments based on blockchain's ledger state.
These utility functions facilitate the usage of emulator's blockchain, as a library for 3rd party tools (e.g. `cadence-tools/test`).

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
