### PR TITLE
Use core contract list from flow-go

### DIFF
--- a/emulator/contracts.go
+++ b/emulator/contracts.go
@@ -21,12 +21,11 @@ package emulator
 import (
 	"fmt"
 
-	"github.com/onflow/flow-go/fvm/systemcontracts"
-
 	"github.com/onflow/flow-emulator/convert"
 
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/templates"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 	flowgo "github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-nft/lib/go/contracts"
 	nftstorefront "github.com/onflow/nft-storefront/lib/go/contracts"

--- a/emulator/contracts.go
+++ b/emulator/contracts.go
@@ -20,6 +20,7 @@ package emulator
 
 import (
 	"fmt"
+
 	"github.com/onflow/flow-go/fvm/systemcontracts"
 
 	"github.com/onflow/flow-emulator/convert"

--- a/emulator/contracts.go
+++ b/emulator/contracts.go
@@ -20,19 +20,21 @@ package emulator
 
 import (
 	"fmt"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 
 	"github.com/onflow/flow-emulator/convert"
 
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/templates"
-	"github.com/onflow/flow-go/fvm"
 	flowgo "github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-nft/lib/go/contracts"
 	nftstorefront "github.com/onflow/nft-storefront/lib/go/contracts"
 )
 
 func NewCommonContracts(chain flowgo.Chain) []ContractDescription {
-	ftAddress := flowsdk.HexToAddress(fvm.FungibleTokenAddress(chain).HexWithPrefix())
+	sc := systemcontracts.SystemContractsForChain(chain.ChainID())
+
+	ftAddress := flowsdk.HexToAddress(sc.FungibleToken.Address.HexWithPrefix())
 	serviceAddress := flowsdk.HexToAddress(chain.ServiceAddress().HexWithPrefix())
 	return []ContractDescription{
 		{

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,7 @@ require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/onflow/cadence v0.42.5
 	github.com/onflow/flow-archive v1.3.4-0.20230503192214-9e81e82d4dcc
-	github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20231016154253-a00dbf7c061f
-	github.com/onflow/flow-go v0.32.4-0.20231128161804-783804dbd577
+	github.com/onflow/flow-go v0.32.4-0.20231120205522-d5395b480516
 	github.com/onflow/flow-go-sdk v0.41.16
 	github.com/onflow/flow-go/crypto v0.24.9
 	github.com/onflow/flow-nft/lib/go/contracts v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,8 @@ require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/onflow/cadence v0.42.5
 	github.com/onflow/flow-archive v1.3.4-0.20230503192214-9e81e82d4dcc
-	github.com/onflow/flow-go v0.32.4-0.20231120205522-d5395b480516
+	github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20231016154253-a00dbf7c061f
+	github.com/onflow/flow-go v0.32.4-0.20231130134727-3c01c7f8966c
 	github.com/onflow/flow-go-sdk v0.41.16
 	github.com/onflow/flow-go/crypto v0.24.9
 	github.com/onflow/flow-nft/lib/go/contracts v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -808,8 +808,8 @@ github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20231016154253-a
 github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20231016154253-a00dbf7c061f/go.mod h1:ZeLxwaBkzuSInESGjL8/IPZWezF+YOYsYbMrZlhN+q4=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20230711213910-baad011d2b13 h1:B4ll7e3j+MqTJv2122Enq3RtDNzmIGRu9xjV7fo7un0=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20230711213910-baad011d2b13/go.mod h1:kTMFIySzEJJeupk+7EmXs0EJ6CBWY/MV9fv9iYQk+RU=
-github.com/onflow/flow-go v0.32.4-0.20231128161804-783804dbd577 h1:gMwpZp72fF/hhgL3vdGakN6GqUbC4HJBAegLLQbt3F4=
-github.com/onflow/flow-go v0.32.4-0.20231128161804-783804dbd577/go.mod h1:YJDAoDjbY4OWBj44XV+Qe+dIwn+hlywUDL5xclOOLbw=
+github.com/onflow/flow-go v0.32.4-0.20231120205522-d5395b480516 h1:dpzCf6EIUNpm7ELr4rwxHaEE7mk2SYKMKJv5BDqdX9M=
+github.com/onflow/flow-go v0.32.4-0.20231120205522-d5395b480516/go.mod h1:bKcX2932bIunkyXBKW9qmw8Z0zXpHol+5xCJCumV/H8=
 github.com/onflow/flow-go-sdk v0.24.0/go.mod h1:IoptMLPyFXWvyd9yYA6/4EmSeeozl6nJoIv4FaEMg74=
 github.com/onflow/flow-go-sdk v0.41.16 h1:HsmHwEVmj+iK+GszHbFseHh7Ii5W3PWOIRNAH/En08Q=
 github.com/onflow/flow-go-sdk v0.41.16/go.mod h1:bVrVNoJKiwB6vW5Qbm5tFAfJBQ5we4uSQWnn9gNAFhQ=

--- a/go.sum
+++ b/go.sum
@@ -808,8 +808,8 @@ github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20231016154253-a
 github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20231016154253-a00dbf7c061f/go.mod h1:ZeLxwaBkzuSInESGjL8/IPZWezF+YOYsYbMrZlhN+q4=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20230711213910-baad011d2b13 h1:B4ll7e3j+MqTJv2122Enq3RtDNzmIGRu9xjV7fo7un0=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20230711213910-baad011d2b13/go.mod h1:kTMFIySzEJJeupk+7EmXs0EJ6CBWY/MV9fv9iYQk+RU=
-github.com/onflow/flow-go v0.32.4-0.20231120205522-d5395b480516 h1:dpzCf6EIUNpm7ELr4rwxHaEE7mk2SYKMKJv5BDqdX9M=
-github.com/onflow/flow-go v0.32.4-0.20231120205522-d5395b480516/go.mod h1:bKcX2932bIunkyXBKW9qmw8Z0zXpHol+5xCJCumV/H8=
+github.com/onflow/flow-go v0.32.4-0.20231130134727-3c01c7f8966c h1:75LED6hmarR0uazKZG8nkqqDlUiqz6NdzkdQQiGjvlI=
+github.com/onflow/flow-go v0.32.4-0.20231130134727-3c01c7f8966c/go.mod h1:YJDAoDjbY4OWBj44XV+Qe+dIwn+hlywUDL5xclOOLbw=
 github.com/onflow/flow-go-sdk v0.24.0/go.mod h1:IoptMLPyFXWvyd9yYA6/4EmSeeozl6nJoIv4FaEMg74=
 github.com/onflow/flow-go-sdk v0.41.16 h1:HsmHwEVmj+iK+GszHbFseHh7Ii5W3PWOIRNAH/En08Q=
 github.com/onflow/flow-go-sdk v0.41.16/go.mod h1:bVrVNoJKiwB6vW5Qbm5tFAfJBQ5we4uSQWnn9gNAFhQ=


### PR DESCRIPTION
## Description

Use the new `SystemContracts.All()` to get the contracts deploy at bootstrapping.

This is related to: https://github.com/onflow/flow-go/pull/5033

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
