### PR TITLE
Updates to align with AccessAPI changes on flow-go master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.19.x'
+        go-version: '1.20.x'
     - uses: actions/cache@v3
       with:
         path: ~/go/pkg/mod
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19.x'
+          go-version: '1.20.x'
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.50
+          version: v1.54
           args: --timeout=10m
 
   docker:

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -4,7 +4,7 @@ on:
     - cron: "0 0 * * *"
 
 env:
-  GO_VERSION: '1.19.2'
+  GO_VERSION: '1.20.11'
   
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ ci: install-tools test check-tidy test coverage check-headers
 
 .PHONY: install-linter
 install-linter:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.46.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.54.2
 
 .PHONY: lint
 lint:

--- a/adapters/access.go
+++ b/adapters/access.go
@@ -21,6 +21,7 @@ package adapters
 import (
 	"context"
 	"fmt"
+
 	"github.com/onflow/flow/protobuf/go/flow/entities"
 
 	jsoncdc "github.com/onflow/cadence/encoding/json"
@@ -390,6 +391,14 @@ func (a *AccessAdapter) GetEventsForBlockIDs(
 }
 
 func (a *AccessAdapter) GetLatestProtocolStateSnapshot(_ context.Context) ([]byte, error) {
+	return nil, nil
+}
+
+func (a *AccessAdapter) GetProtocolStateSnapshotByBlockID(_ context.Context, _ flowgo.Identifier) ([]byte, error) {
+	return nil, nil
+}
+
+func (a *AccessAdapter) GetProtocolStateSnapshotByHeight(_ context.Context, _ uint64) ([]byte, error) {
 	return nil, nil
 }
 

--- a/adapters/sdk.go
+++ b/adapters/sdk.go
@@ -28,7 +28,9 @@ import (
 	emulator "github.com/onflow/flow-emulator/emulator"
 	sdk "github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/templates"
+	"github.com/onflow/flow-go/access"
 	flowgo "github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow/protobuf/go/flow/entities"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -353,7 +355,23 @@ func (b *SDKAdapter) GetLatestProtocolStateSnapshot(_ context.Context) ([]byte, 
 	return nil, nil
 }
 
+func (a *SDKAdapter) GetProtocolStateSnapshotByBlockID(_ context.Context, _ flowgo.Identifier) ([]byte, error) {
+	return nil, nil
+}
+
+func (a *SDKAdapter) GetProtocolStateSnapshotByHeight(_ context.Context, _ uint64) ([]byte, error) {
+	return nil, nil
+}
+
 func (b *SDKAdapter) GetExecutionResultForBlockID(_ context.Context, _ sdk.Identifier) (*sdk.ExecutionResult, error) {
+	return nil, nil
+}
+
+func (b *SDKAdapter) GetSystemTransaction(_ context.Context, _ flowgo.Identifier) (*flowgo.TransactionBody, error) {
+	return nil, nil
+}
+
+func (b *SDKAdapter) GetSystemTransactionResult(_ context.Context, _ flowgo.Identifier, _ entities.EventEncodingVersion) (*access.TransactionResult, error) {
 	return nil, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onflow/cadence v0.42.5
 	github.com/onflow/flow-archive v1.3.4-0.20230503192214-9e81e82d4dcc
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20231016154253-a00dbf7c061f
-	github.com/onflow/flow-go v0.32.4-0.20231115172515-c1ec969fd6f2
+	github.com/onflow/flow-go v0.32.4-0.20231128161804-783804dbd577
 	github.com/onflow/flow-go-sdk v0.41.16
 	github.com/onflow/flow-go/crypto v0.24.9
 	github.com/onflow/flow-nft/lib/go/contracts v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -204,6 +204,3 @@ require (
 	modernc.org/sqlite v1.21.1 // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 )
-
-//TODO: Remove when merged
-replace github.com/onflow/flow-go v0.32.4-0.20231115172515-c1ec969fd6f2 => github.com/AndriiDiachuk/flow-go v0.0.0-20231127171138-fbe6207ef346

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/flow-emulator
 
-go 1.19
+go 1.20
 
 require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,6 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 cloud.google.com/go/storage v1.30.1 h1:uOdMxAs8HExqBlnLtnQyP0YkvbiDpdGShGKtx6U/oNM=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
-github.com/AndriiDiachuk/flow-go v0.0.0-20231127171138-fbe6207ef346 h1:iCl9UFMgllPsW5Nz7bXfER2K+bokdqUMV6jJIbSqwZI=
-github.com/AndriiDiachuk/flow-go v0.0.0-20231127171138-fbe6207ef346/go.mod h1:YJDAoDjbY4OWBj44XV+Qe+dIwn+hlywUDL5xclOOLbw=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-pipeline-go v0.2.2/go.mod h1:4rQ/NZncSvGqNkkOsNpOU1tgoNuIlp9AfUH5G1tvCHc=
 github.com/Azure/azure-storage-blob-go v0.7.0/go.mod h1:f9YQKtsG1nMisotuTPpO0tjNuEjKRYAcJU8/ydDI++4=
@@ -284,6 +282,7 @@ github.com/fxamacker/circlehash v0.3.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
 github.com/gammazero/deque v0.1.0 h1:f9LnNmq66VDeuAlSAapemq/U7hJ2jpIWa4c09q8Dlik=
 github.com/gammazero/deque v0.1.0/go.mod h1:KQw7vFau1hHuM8xmI9RbgKFbAsQFWmBpqQ2KenFLk6M=
+github.com/gammazero/workerpool v1.1.2 h1:vuioDQbgrz4HoaCi2q1HLlOXdpbap5AET7xu5/qj87g=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/getsentry/sentry-go v0.12.0/go.mod h1:NSap0JBYWzHND8oMbyi0+XZhUalc1TBdRL1M71JZW2c=
@@ -809,6 +808,8 @@ github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20231016154253-a
 github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20231016154253-a00dbf7c061f/go.mod h1:ZeLxwaBkzuSInESGjL8/IPZWezF+YOYsYbMrZlhN+q4=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20230711213910-baad011d2b13 h1:B4ll7e3j+MqTJv2122Enq3RtDNzmIGRu9xjV7fo7un0=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20230711213910-baad011d2b13/go.mod h1:kTMFIySzEJJeupk+7EmXs0EJ6CBWY/MV9fv9iYQk+RU=
+github.com/onflow/flow-go v0.32.4-0.20231128161804-783804dbd577 h1:gMwpZp72fF/hhgL3vdGakN6GqUbC4HJBAegLLQbt3F4=
+github.com/onflow/flow-go v0.32.4-0.20231128161804-783804dbd577/go.mod h1:YJDAoDjbY4OWBj44XV+Qe+dIwn+hlywUDL5xclOOLbw=
 github.com/onflow/flow-go-sdk v0.24.0/go.mod h1:IoptMLPyFXWvyd9yYA6/4EmSeeozl6nJoIv4FaEMg74=
 github.com/onflow/flow-go-sdk v0.41.16 h1:HsmHwEVmj+iK+GszHbFseHh7Ii5W3PWOIRNAH/En08Q=
 github.com/onflow/flow-go-sdk v0.41.16/go.mod h1:bVrVNoJKiwB6vW5Qbm5tFAfJBQ5we4uSQWnn9gNAFhQ=

--- a/server/access/streamBackend.go
+++ b/server/access/streamBackend.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/onflow/flow-emulator/emulator"
 	"github.com/onflow/flow-emulator/types"
 	"github.com/onflow/flow-go/engine/access/state_stream"
@@ -35,7 +37,6 @@ import (
 	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
 	"github.com/onflow/flow-go/utils/logging"
 	"github.com/rs/zerolog"
-	"time"
 )
 
 type StateStreamBackend struct {
@@ -246,4 +247,8 @@ func (b StateStreamBackend) getResponseFactory(filter state_stream.EventFilter) 
 			Events:  events,
 		}, nil
 	}
+}
+
+func (b StateStreamBackend) GetRegisterValues(registerIDs flow.RegisterIDs, height uint64) ([]flow.RegisterValue, error) {
+	return nil, status.Errorf(codes.Unimplemented, "not implemented")
 }


### PR DESCRIPTION
This PR pulls in changes from 3 other PRs:

* https://github.com/onflow/flow-emulator/pull/501
* https://github.com/onflow/flow-emulator/pull/514

This aligns the AccessAPI with the latest changes on master

Note: this also updates the go version since the `flow-go` repo now uses features only available in `v1.20`