### PR TITLE
Update docker go version

### DIFF
--- a/cmd/emulator/Dockerfile
+++ b/cmd/emulator/Dockerfile
@@ -3,7 +3,7 @@
 # NOTE: Must be run in the context of the repo's root directory
 
 ## Build the app binary
-FROM --platform=$BUILDPLATFORM golang:1.19 AS build-app
+FROM --platform=$BUILDPLATFORM golang:1.20 AS build-app
 
 # Build the app binary in /app
 RUN mkdir /app


### PR DESCRIPTION
https://github.com/onflow/flow-emulator/pull/518 updated the min version of go, but didn't update the dockerfile. 

Update go version used in the docker build .