### PR TITLE
Fix system chunk transaction

### DIFF
--- a/emulator/block_info_test.go
+++ b/emulator/block_info_test.go
@@ -23,9 +23,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/rs/zerolog"
+
 	"github.com/onflow/flow-emulator/adapters"
 	"github.com/onflow/flow-emulator/emulator"
-	"github.com/rs/zerolog"
 
 	flowsdk "github.com/onflow/flow-go-sdk"
 	flowgo "github.com/onflow/flow-go/model/flow"
@@ -57,7 +58,7 @@ func TestBlockInfo(t *testing.T) {
 						let block = getCurrentBlock()
 						log(block)
 
-						let lastBlock = getBlock(at: block.height - UInt64(1))
+						let lastBlock = getBlock(at: block.height - 1)
 						log(lastBlock)
 					}
 				}
@@ -92,7 +93,7 @@ func TestBlockInfo(t *testing.T) {
 				let block = getCurrentBlock()
 				log(block)
 
-				let lastBlock = getBlock(at: block.height - UInt64(1))
+				let lastBlock = getBlock(at: block.height - 1)
 				log(lastBlock)
 			}
 		`)

--- a/emulator/blockchain.go
+++ b/emulator/blockchain.go
@@ -1763,6 +1763,10 @@ func (b *Blockchain) executeSystemChunkTransaction() error {
 		return err
 	}
 
+	if output.Err != nil {
+		return output.Err
+	}
+
 	b.pendingBlock.events = append(b.pendingBlock.events, output.Events...)
 
 	err = b.pendingBlock.ledgerState.Merge(executionSnapshot)

--- a/emulator/blockchain.go
+++ b/emulator/blockchain.go
@@ -1327,6 +1327,13 @@ func (b *Blockchain) commitBlock() (*flowgo.Block, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// lastly we execute the system chunk transaction
+	err = b.executeSystemChunkTransaction()
+	if err != nil {
+		return nil, err
+	}
+
 	executionSnapshot := b.pendingBlock.Finalize()
 	events := b.pendingBlock.Events()
 
@@ -1357,12 +1364,6 @@ func (b *Blockchain) commitBlock() (*flowgo.Block, error) {
 	// reset pending block using current block and ledger state
 	b.pendingBlock = newPendingBlock(block, ledger, b.clock)
 	b.entropyProvider.LatestBlock = block.ID()
-
-	// lastly we execute the system chunk transaction
-	err = b.executeSystemChunkTransaction()
-	if err != nil {
-		return nil, err
-	}
 
 	return block, nil
 }

--- a/emulator/blockchain.go
+++ b/emulator/blockchain.go
@@ -1756,6 +1756,7 @@ func (b *Blockchain) executeSystemChunkTransaction() error {
 		fvm.WithAuthorizationChecksEnabled(false),
 		fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 		fvm.WithRandomSourceHistoryCallAllowed(true),
+		fvm.WithBlockHeader(b.pendingBlock.Block().Header),
 	)
 
 	executionSnapshot, output, err := b.vm.Run(

--- a/emulator/blockchain.go
+++ b/emulator/blockchain.go
@@ -756,9 +756,13 @@ func bootstrapLedger(
 
 	bootstrap := configureBootstrapProcedure(conf, flowAccountKey, conf.GenesisTokenSupply)
 
-	executionSnapshot, _, err := vm.Run(ctx, bootstrap, ledger)
+	executionSnapshot, output, err := vm.Run(ctx, bootstrap, ledger)
 	if err != nil {
 		return nil, err
+	}
+
+	if output.Err != nil {
+		return nil, output.Err
 	}
 
 	return executionSnapshot, nil

--- a/emulator/random_source_history_test.go
+++ b/emulator/random_source_history_test.go
@@ -24,9 +24,10 @@ import (
 	"github.com/onflow/cadence"
 	flowgo "github.com/onflow/flow-go/model/flow"
 
-	"github.com/onflow/flow-emulator/emulator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-emulator/emulator"
 )
 
 func TestRandomSourceHistoryLowestHeight(t *testing.T) {
@@ -57,7 +58,7 @@ func TestRandomSourceHistoryLowestHeight(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, scriptResult.Error)
 
-	assert.Equal(t, cadence.UInt64(1), scriptResult.Value)
+	assert.Equal(t, cadence.UInt64(2), scriptResult.Value)
 }
 
 func TestRandomSourceHistoryAtBlockHeight(t *testing.T) {
@@ -73,6 +74,9 @@ func TestRandomSourceHistoryAtBlockHeight(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	_, err = b.CommitBlock()
+	require.NoError(t, err)
+
 	serviceAddress := chain.ServiceAddress().Hex()
 
 	scriptCode := fmt.Sprintf(`
@@ -80,12 +84,12 @@ func TestRandomSourceHistoryAtBlockHeight(t *testing.T) {
 
         access(all)
         fun main(): Bool {
-            let sorAt1 = RandomBeaconHistory.sourceOfRandomness(atBlockHeight: 1)
             let sorAt2 = RandomBeaconHistory.sourceOfRandomness(atBlockHeight: 2)
+            let sorAt3 = RandomBeaconHistory.sourceOfRandomness(atBlockHeight: 3)
 
-            assert(sorAt1.blockHeight == 1)
             assert(sorAt2.blockHeight == 2)
-            assert(sorAt1.value != sorAt2.value)
+            assert(sorAt3.blockHeight == 3)
+            assert(sorAt2.value != sorAt3.value)
 
             return true
         }

--- a/emulator/random_source_history_test.go
+++ b/emulator/random_source_history_test.go
@@ -58,7 +58,7 @@ func TestRandomSourceHistoryLowestHeight(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, scriptResult.Error)
 
-	assert.Equal(t, cadence.UInt64(2), scriptResult.Value)
+	assert.Equal(t, cadence.UInt64(1), scriptResult.Value)
 }
 
 func TestRandomSourceHistoryAtBlockHeight(t *testing.T) {
@@ -74,9 +74,6 @@ func TestRandomSourceHistoryAtBlockHeight(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, err = b.CommitBlock()
-	require.NoError(t, err)
-
 	serviceAddress := chain.ServiceAddress().Hex()
 
 	scriptCode := fmt.Sprintf(`
@@ -84,12 +81,12 @@ func TestRandomSourceHistoryAtBlockHeight(t *testing.T) {
 
         access(all)
         fun main(): Bool {
+            let sorAt1 = RandomBeaconHistory.sourceOfRandomness(atBlockHeight: 1)
             let sorAt2 = RandomBeaconHistory.sourceOfRandomness(atBlockHeight: 2)
-            let sorAt3 = RandomBeaconHistory.sourceOfRandomness(atBlockHeight: 3)
 
+            assert(sorAt1.blockHeight == 1)
             assert(sorAt2.blockHeight == 2)
-            assert(sorAt3.blockHeight == 3)
-            assert(sorAt2.value != sorAt3.value)
+            assert(sorAt1.value != sorAt2.value)
 
             return true
         }


### PR DESCRIPTION
## Description

- Handle errors from bootstrapping and system chunk transaction
- Set block header when executing system chunk transaction. `getCurrentBlock` gets called by `RandomBeaconHistory` contract in system chunk transaction, which in turn calls `GetCurrentBlockHeight`, which needs the header.
- Execute the system chunk transaction at the end of the committed block, not when the new pending block has already been set

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
