### PR TITLE
Enable state streaming API over `gRPC`

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -193,7 +193,7 @@ func NewEmulatorServer(logger *zerolog.Logger, conf *Config) *EmulatorServer {
 
 	accessAdapter := adapters.NewAccessAdapter(logger, emulatedBlockchain)
 	livenessTicker := utils.NewLivenessTicker(conf.LivenessCheckTolerance)
-	grpcServer := access.NewGRPCServer(logger, accessAdapter, chain, conf.Host, conf.GRPCPort, conf.GRPCDebug)
+	grpcServer := access.NewGRPCServer(logger, emulatedBlockchain, accessAdapter, chain, conf.Host, conf.GRPCPort, conf.GRPCDebug)
 	restServer, err := access.NewRestServer(logger, emulatedBlockchain, accessAdapter, chain, conf.Host, conf.RESTPort, conf.RESTDebug)
 	if err != nil {
 		logger.Error().Err(err).Msg("❗  Failed to startup REST API")


### PR DESCRIPTION
## Description

By following the changes introduced in https://github.com/onflow/flow-emulator/pull/496, which added support for state streaming API over REST, this PR does the same for the gRPC server that Emulator runs on `127.0.0.1:3569`.

I have tested this with https://github.com/onflow/flow-evm-gateway/pull/11, and it works as expected.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
