### PR TITLE
Differentiate in-memory DBs for blockchain snapshots

### DIFF
--- a/emulator.go
+++ b/emulator.go
@@ -17,7 +17,9 @@
  */
 package emulator
 
-import "github.com/onflow/flow-emulator/emulator"
+import (
+	"github.com/onflow/flow-emulator/emulator"
+)
 
 func New(opts ...emulator.Option) (emulator.Emulator, error) {
 	return emulator.New(opts...)

--- a/emulator/snapshots_test.go
+++ b/emulator/snapshots_test.go
@@ -1,0 +1,71 @@
+/*
+ * Flow Emulator
+ *
+ * Copyright 2019 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package emulator_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateAndLoadSnapshots(t *testing.T) {
+
+	t.Parallel()
+
+	blockchain1, adapter1 := setupTransactionTests(t)
+	blockchain2, adapter2 := setupTransactionTests(t)
+
+	err := blockchain1.CreateSnapshot("BlockchainCreated")
+	require.NoError(t, err)
+
+	err = blockchain2.CreateSnapshot("BlockchainCreated")
+	require.NoError(t, err)
+
+	_, _ = DeployAndGenerateAddTwoScript(t, adapter1)
+	_, _ = DeployAndGenerateAddTwoScript(t, adapter2)
+
+	err = blockchain1.CreateSnapshot("ContractDeployed")
+	require.NoError(t, err)
+
+	err = blockchain2.CreateSnapshot("ContractDeployed")
+	require.NoError(t, err)
+
+	block1, err := blockchain1.GetLatestBlock()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), block1.Header.Height)
+
+	block2, err := blockchain2.GetLatestBlock()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), block2.Header.Height)
+
+	err = blockchain1.LoadSnapshot("BlockchainCreated")
+	require.NoError(t, err)
+
+	err = blockchain2.LoadSnapshot("BlockchainCreated")
+	require.NoError(t, err)
+
+	block1, err = blockchain1.GetLatestBlock()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), block1.Header.Height)
+
+	block2, err = blockchain2.GetLatestBlock()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), block2.Header.Height)
+}

--- a/storage/sqlite/store.go
+++ b/storage/sqlite/store.go
@@ -31,6 +31,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	_ "github.com/glebarez/go-sqlite"
 
@@ -53,6 +54,7 @@ type Store struct {
 	url           string
 	mu            sync.RWMutex
 	snapshotNames []string
+	id            int64
 }
 
 // New returns a new in-memory Store implementation.
@@ -82,6 +84,7 @@ func New(url string) (store *Store, err error) {
 	store = &Store{
 		db:  db,
 		url: url,
+		id:  time.Now().UnixMilli(),
 	}
 
 	store.DataSetter = store
@@ -173,7 +176,7 @@ func (s *Store) LoadSnapshot(name string) error {
 
 	var dbFile string
 	if s.url == InMemory {
-		dbFile = fmt.Sprintf("file:%s?mode=memory&cache=shared", name)
+		dbFile = fmt.Sprintf("file:%s%d?mode=memory&cache=shared", name, s.id)
 		db, err := sql.Open("sqlite", dbFile)
 		if err != nil {
 			return err
@@ -218,10 +221,10 @@ func (s *Store) CreateSnapshot(name string) error {
 		return fmt.Errorf("snapshot is not supported with current configuration")
 	}
 
-	var dbfile string
+	var dbFile string
 	if s.url == InMemory {
-		dbfile = fmt.Sprintf("file:%s?mode=memory&cache=shared", name)
-		db, err := sql.Open("sqlite", dbfile)
+		dbFile = fmt.Sprintf("file:%s%d?mode=memory&cache=shared", name, s.id)
+		db, err := sql.Open("sqlite", dbFile)
 		if err != nil {
 			return err
 		}
@@ -235,10 +238,10 @@ func (s *Store) CreateSnapshot(name string) error {
 		}
 
 	} else {
-		dbfile = filepath.Join(s.url, snapshotPrefix+name)
+		dbFile = filepath.Join(s.url, snapshotPrefix+name)
 	}
 
-	_, err := s.db.Exec(fmt.Sprintf("VACUUM main INTO '%s'", dbfile))
+	_, err := s.db.Exec(fmt.Sprintf("VACUUM main INTO '%s'", dbFile))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-cli/issues/1376

## Description

For tools that may use multiple Emulator instances in the same process (e.g. `flow test`), creation & loading of snapshots is not isolated, due to the usage of in-memory databases in sqlite3 (https://www.sqlite.org/inmemorydb.html).

This can result in some conflicts, if snapshots with the same name are created in different instances, for example:

```bash
❌ Command Error: Execution failed:
error: panic: out of memory (7)
   --> Test:155:12
```

The sqlite3 error is misleading, but it basically means that the in-memory database already exists.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
