### PR TITLE
Update to Cadence v1.0.0-M9

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ and if you plan to run the emulator with Docker you must use the environment var
 | `--chain-id`                  | `FLOW_CHAINID`               | `emulator`     | Chain to simulate, if 'mainnet' or 'testnet' values are used, you will be able to run transactions against that network and a local fork will be created..  Valid values are: 'emulator', 'testnet', 'mainnet'                                     |
 | `--redis-url`                 | `FLOW_REDIS_URL`             | ''             | Redis-server URL for persisting redis storage backend ( `redis://[[username:]password@]host[:port][/database]` )                                                                                                                                  |
 | `--start-block-height`        | `FLOW_STARTBLOCKHEIGHT`             | `0`             | Start block height to use when starting the network using 'testnet' or 'mainnet' as the chain-id    |
-| `--evm-enabled` | `FLOW_EVMENABLED` | `false`         | Enable evm support |
 
 | `--legacy-upgrade` | `FLOW_LEGACYUPGRADE` | `false`         | Enable upgrading of legacy contracts |
 

--- a/cmd/emulator/start/start.go
+++ b/cmd/emulator/start/start.go
@@ -74,7 +74,6 @@ type Config struct {
 	SqliteURL                    string        `default:"" flag:"sqlite-url" info:"sqlite db URL for persisting sqlite storage backend "`
 	CoverageReportingEnabled     bool          `default:"false" flag:"coverage-reporting" info:"enable Cadence code coverage reporting"`
 	LegacyContractUpgradeEnabled bool          `default:"false" flag:"legacy-upgrade" info:"enable Cadence legacy contract upgrade"`
-	EVMEnabled                   bool          `default:"false" flag:"evm-enabled" info:"enable EVM support"`
 	// todo temporarily disabled until remote register endpoint is re-enabled
 	// StartBlockHeight         uint64        `default:"0" flag:"start-block-height" info:"block height to start the emulator at. only valid when forking Mainnet or Testnet"`
 }
@@ -202,7 +201,6 @@ func Cmd(getServiceKey serviceKeyFunc) *cobra.Command {
 				SqliteURL:                    conf.SqliteURL,
 				CoverageReportingEnabled:     conf.CoverageReportingEnabled,
 				LegacyContractUpgradeEnabled: conf.LegacyContractUpgradeEnabled,
-				EVMEnabled:                   conf.EVMEnabled,
 				// todo temporarily disabled until remote register endpoint is re-enabled
 				// StartBlockHeight:          conf.StartBlockHeight,
 			}

--- a/emulator/accounts_test.go
+++ b/emulator/accounts_test.go
@@ -214,7 +214,7 @@ func TestCreateAccount(t *testing.T) {
 		account, err := LastCreatedAccount(b, result)
 		require.NoError(t, err)
 
-		assert.Equal(t, "0000000000000005", account.Address.Hex())
+		assert.Equal(t, "0000000000000006", account.Address.Hex())
 		assert.Equal(t, uint64(0x186a0), account.Balance)
 		require.Len(t, account.Keys, 1)
 		assert.Equal(t, accountKey.PublicKey.Encode(), account.Keys[0].PublicKey.Encode())

--- a/emulator/script_test.go
+++ b/emulator/script_test.go
@@ -290,7 +290,6 @@ func TestEVM(t *testing.T) {
 
 	b, err := emulator.New(
 		emulator.WithScriptGasLimit(gasLimit),
-		emulator.WithEVMEnabled(true),
 	)
 	require.NoError(t, err)
 

--- a/emulator/transaction_test.go
+++ b/emulator/transaction_test.go
@@ -2167,7 +2167,7 @@ func TestEVMTransaction(t *testing.T) {
 		serviceAddr.HexWithPrefix(),
 	))
 
-	b, adapter := setupTransactionTests(t, emulator.WithEVMEnabled(true))
+	b, adapter := setupTransactionTests(t)
 
 	// generate random address
 	genArr := make([]cadence.Value, 20)

--- a/go.mod
+++ b/go.mod
@@ -13,11 +13,11 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v1.0.0-M8
+	github.com/onflow/cadence v1.0.0-M9
 	github.com/onflow/crypto v0.25.0
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240227190927-0e6ce7e3222b
-	github.com/onflow/flow-go v0.34.0-crescendo-preview.5.0.20240228222755-c41bc8a25122
-	github.com/onflow/flow-go-sdk v1.0.0-M7
+	github.com/onflow/flow-go v0.34.0-crescendo-preview.5.0.20240305144514-8878690ed49e
+	github.com/onflow/flow-go-sdk v1.0.0-M8
 	github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240214230837-cd2c42e54b4a
 	github.com/onflow/flow/protobuf/go/flow v0.3.7
 	github.com/prometheus/client_golang v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -1984,8 +1984,8 @@ github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f h1:Z8/PgTqOgOg02MTRpTBYO2k16FE6z4wEOtaC2WBR9Xo=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-M8 h1:ioQ7TyhpsIaImAC7Xn2r8kIgIBdimvyuWeKlGfRxWB8=
-github.com/onflow/cadence v1.0.0-M8/go.mod h1:a4mccDU90hmuxCLUFzs9J/ANG/rYbFa36h4Z0bBAqNU=
+github.com/onflow/cadence v1.0.0-M9 h1:hYqh6iok2X+QEyAlvoEY1k57EV7Yt8+Iz5+lGvjey3o=
+github.com/onflow/cadence v1.0.0-M9/go.mod h1:a4mccDU90hmuxCLUFzs9J/ANG/rYbFa36h4Z0bBAqNU=
 github.com/onflow/crypto v0.25.0 h1:BeWbLsh3ZD13Ej+Uky6kg1PL1ZIVBDVX+2MVBNwqddg=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.2-0.20240227190927-0e6ce7e3222b h1:oXHQft30sElpK7G3xWB5tEizI2G+S4p64iVh0LtX4E0=
@@ -1996,11 +1996,11 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240213220156-959b70719876 
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240213220156-959b70719876/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240213220156-959b70719876 h1:fZj39XxayIL7uvKvonNI3MtQM3wsFJ8oRl/XW/0rn7A=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240213220156-959b70719876/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.34.0-crescendo-preview.5.0.20240228222755-c41bc8a25122 h1:6R1L5Ji+lEWdTRcqeTLVLGPX1FqiWHeXHnRKAUsciSE=
-github.com/onflow/flow-go v0.34.0-crescendo-preview.5.0.20240228222755-c41bc8a25122/go.mod h1:HSffipIVOyXvK3/gsYU13EwRMxbuK591hmjqF36nbEI=
+github.com/onflow/flow-go v0.34.0-crescendo-preview.5.0.20240305144514-8878690ed49e h1:7gvhYRK4dY+Q6okKp9lwM5TU8sKUALZ6N+ViSKQ8MT4=
+github.com/onflow/flow-go v0.34.0-crescendo-preview.5.0.20240305144514-8878690ed49e/go.mod h1:w8WQrc76969OVrVDVoCarEgPKting6IEThSC7CjIiz8=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-M7 h1:5EhtgpupjdhJZoHpu8AhA7++AroGL6BFpb8D0AYIUQw=
-github.com/onflow/flow-go-sdk v1.0.0-M7/go.mod h1:aXSavLzoRlz5FiMjcI7p5QhihWScGctxydzf4dv/avo=
+github.com/onflow/flow-go-sdk v1.0.0-M8 h1:jnWA6X29sZlMsrIjdxoEkBAJsZBazXTcQJ/wPw1ZbfU=
+github.com/onflow/flow-go-sdk v1.0.0-M8/go.mod h1:qFy2LF0DKfYsEnyEaIxD0frA/zAMc5hURbnqTrSZBjA=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240214230837-cd2c42e54b4a h1:xMEtuQp4+ltfEZcw+4smv4wechSBAus4yEAtPghXZeQ=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240214230837-cd2c42e54b4a/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240214230837-cd2c42e54b4a h1:Ark2dPAaSxSr45G5WJjB1P5H0tFtXnHcOIp+dM146yo=

--- a/server/server.go
+++ b/server/server.go
@@ -106,7 +106,6 @@ type Config struct {
 	MinimumStorageReservation cadence.UFix64
 	StorageMBPerFLOW          cadence.UFix64
 	TransactionFeesEnabled    bool
-	EVMEnabled                bool
 	TransactionMaxGasLimit    uint64
 	ScriptGasLimit            uint64
 	Persist                   bool

--- a/server/server.go
+++ b/server/server.go
@@ -371,7 +371,6 @@ func configureBlockchain(logger *zerolog.Logger, conf *Config, store storage.Sto
 		emulator.WithMinimumStorageReservation(conf.MinimumStorageReservation),
 		emulator.WithStorageMBPerFLOW(conf.StorageMBPerFLOW),
 		emulator.WithTransactionFeesEnabled(conf.TransactionFeesEnabled),
-		emulator.WithEVMEnabled(conf.EVMEnabled),
 		emulator.WithChainID(conf.ChainID),
 		emulator.WithContractRemovalEnabled(conf.ContractRemovalEnabled),
 	}


### PR DESCRIPTION
Closes #597

## Description

Automatically update to:
- [onflow/cadence v1.0.0-M9](https://github.com/onflow/cadence/releases/tag/v1.0.0-M9)
- [onflow/flow-go-sdk v1.0.0-M8](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-M8)
- [onflow/flow-go 8878690ed49e1f28ff2ca54eaa1ded77fb344b8b](https://github.com/onflow/flow-go/commit/8878690ed49e1f28ff2ca54eaa1ded77fb344b8b)

Cherry-picked the commits from https://github.com/onflow/flow-emulator/pull/584#issuecomment-1980966664 by @janezpodhostnik 🙏 
