### PR TITLE
Update to Cadence v1.0.0-preview.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,11 +12,11 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v1.0.0-preview.15
+	github.com/onflow/cadence v1.0.0-preview.16
 	github.com/onflow/crypto v0.25.0
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240305214031-d81e0c3b42f3
-	github.com/onflow/flow-go v0.34.0-crescendo-preview.6.0.20240318184044-4d7d92181133
-	github.com/onflow/flow-go-sdk v1.0.0-preview.13
+	github.com/onflow/flow-go v0.34.0-crescendo-preview.7.0.20240320194536-a387f4df1cca
+	github.com/onflow/flow-go-sdk v1.0.0-preview.14
 	github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240305213046-9026973838d7
 	github.com/onflow/flow/protobuf/go/flow v0.3.7
 	github.com/prometheus/client_golang v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -1995,8 +1995,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.6.1-0.20240308163425-dc825c20b1a2 h1:jJLDswfAVB0bHCu1y1FPdKukPcTNmN+jYEX9S9phbv0=
 github.com/onflow/atree v0.6.1-0.20240308163425-dc825c20b1a2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.15 h1:63PARrAbBSj0mMv7uQTajzbuAxtCZ+e0AfJXthkgWtk=
-github.com/onflow/cadence v1.0.0-preview.15/go.mod h1:no8+e5V51B9mgfi4U9xdeH+GxcJdoKKDP9gdxEj9Jdg=
+github.com/onflow/cadence v1.0.0-preview.16 h1:Pu/e7Z1P2nWn+T8/bAcolBS/0JWledYYlqmmhwJTM1o=
+github.com/onflow/cadence v1.0.0-preview.16/go.mod h1:no8+e5V51B9mgfi4U9xdeH+GxcJdoKKDP9gdxEj9Jdg=
 github.com/onflow/crypto v0.25.0 h1:BeWbLsh3ZD13Ej+Uky6kg1PL1ZIVBDVX+2MVBNwqddg=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.2-0.20240305214031-d81e0c3b42f3 h1:UNLms46HthnzKTR3DVQmEoDerf4EtNUMfkombIeT3U8=
@@ -2007,11 +2007,11 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240305212555-29d91e18f0c1 
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240305212555-29d91e18f0c1/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240305212555-29d91e18f0c1 h1:7BkqJ21EQAbYCZqLj2xCIqJvhrHNCXe9BfLTEiQqIx0=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240305212555-29d91e18f0c1/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.34.0-crescendo-preview.6.0.20240318184044-4d7d92181133 h1:AZVNZGsjgHBIuBkvGVvq0x29w+I4dBSadQd1O0Na63Y=
-github.com/onflow/flow-go v0.34.0-crescendo-preview.6.0.20240318184044-4d7d92181133/go.mod h1:BEoeZRwJAQ3+V/50ZuYApW7UnkaEgkVaOeZafN08TEI=
+github.com/onflow/flow-go v0.34.0-crescendo-preview.7.0.20240320194536-a387f4df1cca h1:tt4fGOF4GUPjrkEV+DfUMZPdvNeUm9Dp7rbi2s6Pa1o=
+github.com/onflow/flow-go v0.34.0-crescendo-preview.7.0.20240320194536-a387f4df1cca/go.mod h1:jZ3i7SZe3jDwWYrBr7MDNFmfiPbDUyX9ZVwgrlj/sBQ=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.13 h1:ldFlReq9yu6T1z4njT5YPVri7tF5MsE7NzCcBiFd/1w=
-github.com/onflow/flow-go-sdk v1.0.0-preview.13/go.mod h1:79FoT96P0asBWA+bf4RmvYdbFi517LowSnkUbqdFkm0=
+github.com/onflow/flow-go-sdk v1.0.0-preview.14 h1:co4RFTxbfVz24i8LICErDN+SE63ckb5tRJPROkOpw3E=
+github.com/onflow/flow-go-sdk v1.0.0-preview.14/go.mod h1:oKomgYV3sR3mxsYMe4L6I5pouJvP2xeHfaUpHfzv7aY=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240305213046-9026973838d7 h1:0/s3DzQp3JHWuuz3DpGwniFShtgEy3wq1uBB+4uOG1I=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240305213046-9026973838d7/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240305213046-9026973838d7 h1:VU294Tk/Ra/UuuJbArLILA+x+4qX5qGPTY/kokNKyA4=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.0.0-preview.16](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.16)
- [onflow/flow-go-sdk v1.0.0-preview.14](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.14)
- [onflow/flow-go a387f4df1ccab8d2e74558279140e544149f946e](https://github.com/onflow/flow-go/commit/a387f4df1ccab8d2e74558279140e544149f946e)

