### PR TITLE
Update Flow Go v0.34.0-crescendo-preview.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/onflow/cadence v1.0.0-preview.23
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240429192223-e696a8e439b5
-	github.com/onflow/flow-go v0.34.0-crescendo-preview.16
+	github.com/onflow/flow-go v0.34.0-crescendo-preview.17
 	github.com/onflow/flow-go-sdk v1.0.0-preview.22
 	github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240429184308-40c3de711140
 	github.com/onflow/flow/protobuf/go/flow v0.4.1-0.20240412170550-911321113030

--- a/go.sum
+++ b/go.sum
@@ -2050,8 +2050,8 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240424211859-3ff4c0fe2a1e 
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240424211859-3ff4c0fe2a1e/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240424211859-3ff4c0fe2a1e h1:jl7SYAui/gYRmBofrY//Ln8ixRJwvLzvwLstNfRKmWY=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240424211859-3ff4c0fe2a1e/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.34.0-crescendo-preview.16 h1:GTOLB2FTG4En91WAd51ReNM5zGJ56KJY9k7AN/ZsCMw=
-github.com/onflow/flow-go v0.34.0-crescendo-preview.16/go.mod h1:WbsDXtDBGRil+pQevdxTlP2r3a67/Aq5Y7+ab/P0aFw=
+github.com/onflow/flow-go v0.34.0-crescendo-preview.17 h1:HnISCj+nZkfwDHmVF1VmbmyuVbOH76GNGKFTMbthD7c=
+github.com/onflow/flow-go v0.34.0-crescendo-preview.17/go.mod h1:WbsDXtDBGRil+pQevdxTlP2r3a67/Aq5Y7+ab/P0aFw=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
 github.com/onflow/flow-go-sdk v1.0.0-preview.22 h1:ahHlppdDd4TjHMfnE73SD15AR16KTgbczdhFjGjAtFM=
 github.com/onflow/flow-go-sdk v1.0.0-preview.22/go.mod h1:0hJfpIajLtBvaAUfJAdvWx6WBVp5hS0DJidc0NJLgE4=


### PR DESCRIPTION
## Description
Update flow go to [v0.34.0-crescendo-preview.17](https://github.com/onflow/flow-go/releases/tag/v0.34.0-crescendo-preview.17)

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
