### PR TITLE
Update to Cadence v1.0.0-preview.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,11 +12,11 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v1.0.0-preview.24
+	github.com/onflow/cadence v1.0.0-preview.25
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240429192223-e696a8e439b5
-	github.com/onflow/flow-go v0.34.0-crescendo-preview.10-staged-contracts-3.0.20240501173610-13b1393dd6b7
-	github.com/onflow/flow-go-sdk v1.0.0-preview.24
+	github.com/onflow/flow-go v0.34.0-crescendo-preview.18
+	github.com/onflow/flow-go-sdk v1.0.0-preview.25
 	github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240429184308-40c3de711140
 	github.com/onflow/flow/protobuf/go/flow v0.4.1-0.20240412170550-911321113030
 	github.com/prometheus/client_golang v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -1978,8 +1978,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.7.0-rc.1 h1:g2DFhC3JeaA+L7/HZOp4NwE+OfxvfJ8nibymHHw7i3g=
 github.com/onflow/atree v0.7.0-rc.1/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.24 h1:fMF/4RrpeifPQzXuNnk6uM0sEdozCIo5h8c4mV6bXBA=
-github.com/onflow/cadence v1.0.0-preview.24/go.mod h1:fGhLBbuEmv5rh48qv0ZS0tUz53gxWsHpB4dPsF09h6E=
+github.com/onflow/cadence v1.0.0-preview.25 h1:kSmWjxmg9PS+bsk8C3j1NUTkFAl/jNrintVhlh6miM0=
+github.com/onflow/cadence v1.0.0-preview.25/go.mod h1:fGhLBbuEmv5rh48qv0ZS0tUz53gxWsHpB4dPsF09h6E=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -1991,11 +1991,11 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240424211859-3ff4c0fe2a1e 
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240424211859-3ff4c0fe2a1e/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240424211859-3ff4c0fe2a1e h1:jl7SYAui/gYRmBofrY//Ln8ixRJwvLzvwLstNfRKmWY=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240424211859-3ff4c0fe2a1e/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.34.0-crescendo-preview.10-staged-contracts-3.0.20240501173610-13b1393dd6b7 h1:aOLrhprrKUL0nz5kOwmILS1D0VnBdiEqSCHPTrJlMAQ=
-github.com/onflow/flow-go v0.34.0-crescendo-preview.10-staged-contracts-3.0.20240501173610-13b1393dd6b7/go.mod h1:KWRml7K7SEe709qbRIrIfohIxvtCcaWEZ7ySADxHTM8=
+github.com/onflow/flow-go v0.34.0-crescendo-preview.18 h1:Bre7uU/n1PjOEcIkTtaJDo4T5tngjKcr/cAOvxr3se4=
+github.com/onflow/flow-go v0.34.0-crescendo-preview.18/go.mod h1:bwjzi2kSev1emRVN685FqYfCLYcZ6t2A5z5ztYXfvH8=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.24 h1:Z3Q97UqVLmgjhMwgUkP0I/zWkrxWjzYFCqTMLYNFP8M=
-github.com/onflow/flow-go-sdk v1.0.0-preview.24/go.mod h1:dcBUQSI0rFV7drO9L5yqa2X8MDS+wNQymq421OsZ/5g=
+github.com/onflow/flow-go-sdk v1.0.0-preview.25 h1:wL/+cK7oxSww31qSqTpt1Yfr26c8hJ8YHh9nIdq6PlI=
+github.com/onflow/flow-go-sdk v1.0.0-preview.25/go.mod h1:Px1fQdB7WFC0yhYsEM3rhKzuE+Zi8GpBjR4qVuDAwMA=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240429184308-40c3de711140 h1:oTj4RGgfuJSSBE1aDVrlh6avxKBMraucpNtRg0K+yhg=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240429184308-40c3de711140/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240429184308-40c3de711140 h1:7NwSIG4SEdm+96gr+Aaqx291jZ/Bqkxk/ghVnens9CU=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.0.0-preview.25](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.25)
- [onflow/flow-go-sdk v1.0.0-preview.25](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.25)
- [onflow/flow-go v0.34.0-crescendo-preview.18](https://github.com/onflow/flow-go/releases/tag/v0.34.0-crescendo-preview.18)

