### PR TITLE
Change nightly build go version to v1.21.9

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -4,7 +4,7 @@ on:
     - cron: "0 0 * * *"
 
 env:
-  GO_VERSION: '1.21.11'
+  GO_VERSION: '1.21.9'
   
 jobs:
   build:


### PR DESCRIPTION
## Description

Nightly builds are failing because v1.21.11 doesn't exist.  This is latest 1.21.x

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
