### PR TITLE
add verbose error output on migrations through emulator

### DIFF
--- a/storage/migration/cadence1.go
+++ b/storage/migration/cadence1.go
@@ -56,6 +56,7 @@ func MigrateCadence1(
 			NWorker:                           nWorker,
 			DiffMigrations:                    false,
 			LogVerboseDiff:                    false,
+			VerboseErrorOutput:                true, // turn on verbose error output for emulator
 			CheckStorageHealthBeforeMigration: false,
 			ChainID:                           flow.Emulator,
 			EVMContractChange:                 evmContractChange,


### PR DESCRIPTION
Closes #https://github.com/onflow/flow-cli/issues/1625


## Description

enable verbose error output on migrations through the emulator as devs would want those logs instead of sifting through the report

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
