### PR TITLE
Update to Cadence v1.0.0-preview.32

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,11 +12,11 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v1.0.0-preview.30
+	github.com/onflow/cadence v1.0.0-preview.32
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.0.0
-	github.com/onflow/flow-go v0.35.10-crescendo-preview.25.0.20240530124823-b968034713f6
-	github.com/onflow/flow-go-sdk v1.0.0-preview.31
+	github.com/onflow/flow-go v0.35.10-crescendo-preview.25.0.20240604172940-c504b454e576
+	github.com/onflow/flow-go-sdk v1.0.0-preview.34
 	github.com/onflow/flow-nft/lib/go/contracts v1.2.1
 	github.com/onflow/flow/protobuf/go/flow v0.4.4
 	github.com/prometheus/client_golang v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -1984,8 +1984,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.7.0-rc.2 h1:mZmVrl/zPlfI44EjV3FdR2QwIqT8nz1sCONUBFcML/U=
 github.com/onflow/atree v0.7.0-rc.2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.30 h1:5iBXjW86r+YDD6tF9mF2Eta2uCK8P2BfVCXHUCiwMwE=
-github.com/onflow/cadence v1.0.0-preview.30/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
+github.com/onflow/cadence v1.0.0-preview.32 h1:M4IdYtUt78D33vLegoNtNU4H/PoBy9J8Xk42EiCRkiE=
+github.com/onflow/cadence v1.0.0-preview.32/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -1997,11 +1997,11 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0 h1:mToacZ5NWqtlWwk/7RgIl/jeKB/
 github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.35.10-crescendo-preview.25.0.20240530124823-b968034713f6 h1:4cGWwYF2VxGEOHB8XGKRr0IoJ0dMGlnYGrSh+vXoeIg=
-github.com/onflow/flow-go v0.35.10-crescendo-preview.25.0.20240530124823-b968034713f6/go.mod h1:xBj5GtXRXD20J/cwQpraFW2EUeapdv4VRoKBrtPi7uo=
+github.com/onflow/flow-go v0.35.10-crescendo-preview.25.0.20240604172940-c504b454e576 h1:K5EFNvwiimx/wzUGDwCq6Az5Rk9EMG/OpDgjkOZpDrM=
+github.com/onflow/flow-go v0.35.10-crescendo-preview.25.0.20240604172940-c504b454e576/go.mod h1:KMLJY5pVkDsfOpm4prKwhVlVOLLXQa/4Ph6H/sQu+mM=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.31 h1:TWJ7Wi2ZKhU3/xGKOftmxFO2d76xKhQVh3rcr0DW3IY=
-github.com/onflow/flow-go-sdk v1.0.0-preview.31/go.mod h1:vinot5qmZxZ+QV1m67/rK+2iK83iAkVg9Vbiy/Q0TO4=
+github.com/onflow/flow-go-sdk v1.0.0-preview.34 h1:FXzQfz9rK08EdoZ7gTy7Ve0at6bgcV1iQN6rtrQG/7I=
+github.com/onflow/flow-go-sdk v1.0.0-preview.34/go.mod h1:blgTAtthpHf58QZiyDUaLBabMlebMtbdzvTf2K5+dds=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1 h1:woAAS5z651sDpi7ihAHll8NvRS9uFXIXkL6xR+bKFZY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.0.0-preview.32](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.32)
- [onflow/flow-go-sdk v1.0.0-preview.34](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.34)
- [onflow/flow-go c504b454e576](https://github.com/onflow/flow-go/commit/c504b454e576)

