### PR TITLE
Updated flow-go version, removed replace statement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/onflow/cadence v1.0.0-preview.36
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.3.0
-	github.com/onflow/flow-go v0.35.14-crescendo-preview.27.0.20240626210601-604590f19db9
+	github.com/onflow/flow-go v0.36.1-0.20240712165317-d0d12c8e892c
 	github.com/onflow/flow-go-sdk v1.0.0-preview.38
 	github.com/onflow/flow-nft/lib/go/contracts v1.2.1
 	github.com/onflow/flow/protobuf/go/flow v0.4.5
@@ -236,5 +236,3 @@ require (
 	nhooyr.io/websocket v1.8.7 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
-
-replace github.com/onflow/flow-go v0.35.14-crescendo-preview.27.0.20240626210601-604590f19db9 => github.com/AndriiDiachuk/flow-go v0.0.0-20240711140457-69e2f4007091

--- a/go.sum
+++ b/go.sum
@@ -932,8 +932,6 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
 git.sr.ht/~sbinet/gg v0.3.1/go.mod h1:KGYtlADtqsqANL9ueOFkWymvzUvLMQllU5Ixo+8v3pc=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
-github.com/AndriiDiachuk/flow-go v0.0.0-20240711140457-69e2f4007091 h1:9lI8wMf2HDx8jCEXWwqxAZYBJ9+yq0U7Kd7GWQ1lviE=
-github.com/AndriiDiachuk/flow-go v0.0.0-20240711140457-69e2f4007091/go.mod h1:zyDRnDHQ7am6Ial1Sk9w5dPB9gQZzAtzYLJIYyLA3z8=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.21.1/go.mod h1:fBF9PQNqB8scdgpZ3ufzaLntG0AG7C1WjPMsiFOmfHM=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.0/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
@@ -2065,6 +2063,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0 h1:mToacZ5NWqtlWwk/7RgIl/jeKB/
 github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
+github.com/onflow/flow-go v0.36.1-0.20240712165317-d0d12c8e892c h1:9hL3QX9MhUjsz159LlAr4jE0zF9e1FoQIH4hNXoQsxI=
+github.com/onflow/flow-go v0.36.1-0.20240712165317-d0d12c8e892c/go.mod h1:zyDRnDHQ7am6Ial1Sk9w5dPB9gQZzAtzYLJIYyLA3z8=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
 github.com/onflow/flow-go-sdk v1.0.0-preview.38 h1:vzTXhNkklnuxFaqhFeLPry+sud6LzhRMFFQveYJuXt4=
 github.com/onflow/flow-go-sdk v1.0.0-preview.38/go.mod h1:SuSH+SB9jONwjhXrb402JM7HfDLAcXRABN1wF+iYAfw=


### PR DESCRIPTION
In this PR was updated flow-go version, removed replace statement. Clean up after https://github.com/onflow/flow-emulator/pull/707.