### PR TITLE
Update to Cadence v1.0.0-preview.38

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/onflow/cadence v1.0.0-preview.38
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.3.0
-	github.com/onflow/flow-go v0.36.2-0.20240717162253-d5d2e606ef53
+	github.com/onflow/flow-go v0.36.2-0.20240717214129-9ea6faeee3e7
 	github.com/onflow/flow-go-sdk v1.0.0-preview.41
 	github.com/onflow/flow-nft/lib/go/contracts v1.2.1
 	github.com/onflow/flow/protobuf/go/flow v0.4.5

--- a/go.sum
+++ b/go.sum
@@ -2058,8 +2058,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0 h1:mToacZ5NWqtlWwk/7RgIl/jeKB/
 github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.36.2-0.20240717162253-d5d2e606ef53 h1:d90+yOBSXYchn4U5Rgo82INdLMD4MkgkH1DfSjv9eKo=
-github.com/onflow/flow-go v0.36.2-0.20240717162253-d5d2e606ef53/go.mod h1:6M6tijXZLxQkzsF3IVIIuRk2lzHvMg2mVnirtLaMW18=
+github.com/onflow/flow-go v0.36.2-0.20240717214129-9ea6faeee3e7 h1:ZlqdL88tBWCGqooqaFPgspwuwCPb+e2xE5imLEEYfTA=
+github.com/onflow/flow-go v0.36.2-0.20240717214129-9ea6faeee3e7/go.mod h1:6M6tijXZLxQkzsF3IVIIuRk2lzHvMg2mVnirtLaMW18=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
 github.com/onflow/flow-go-sdk v1.0.0-preview.41 h1:pOUAIQdlWuc90tQzYixCXkqmnoorDgsFxTu2J1wlhHA=
 github.com/onflow/flow-go-sdk v1.0.0-preview.41/go.mod h1:FyJiLluqK+sNo+ky9VU6HSwVkvhv5/fKH1sIKI1yrrI=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.0.0-preview.38](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.38)
- [onflow/flow-go-sdk v1.0.0-preview.41](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.41)
- [onflow/flow-go 9ea6faeee3e7](https://github.com/onflow/flow-go/commit/9ea6faeee3e7)

