### PR TITLE
Add support for `EVM.heartbeat` resource on system chunk transaction

### DIFF
--- a/emulator/blockchain.go
+++ b/emulator/blockchain.go
@@ -1801,6 +1801,8 @@ func (b *Blockchain) systemChunkTransaction() (*flowgo.TransactionBody, error) {
 			RandomBeaconHistoryAddress: b.GetChain().ServiceAddress().Hex(),
 		},
 	)
+	// We should move this to `templates.Environment` struct
+	script = strings.ReplaceAll(script, "\"EVM\"", b.GetChain().ServiceAddress().HexWithPrefix())
 
 	tx := flowgo.NewTransactionBody().
 		SetScript([]byte(script)).

--- a/emulator/blockchain.go
+++ b/emulator/blockchain.go
@@ -1795,20 +1795,30 @@ func (b *Blockchain) GetSourceFile(location common.Location) string {
 }
 
 func (b *Blockchain) systemChunkTransaction() (*flowgo.TransactionBody, error) {
+	serviceAddress := b.GetChain().ServiceAddress()
+
 	script := templates.ReplaceAddresses(
 		systemChunkTransactionTemplate,
 		templates.Environment{
-			RandomBeaconHistoryAddress: b.GetChain().ServiceAddress().Hex(),
+			RandomBeaconHistoryAddress: serviceAddress.Hex(),
 		},
 	)
-	// We should move this to `templates.Environment` struct
-	script = strings.ReplaceAll(script, "\"EVM\"", b.GetChain().ServiceAddress().HexWithPrefix())
+
+	// TODO: move this to `templates.Environment` struct
+	script = strings.ReplaceAll(
+		script,
+		`import EVM from "EVM"`,
+		fmt.Sprintf(
+			"import EVM from %s",
+			serviceAddress.HexWithPrefix(),
+		),
+	)
 
 	tx := flowgo.NewTransactionBody().
 		SetScript([]byte(script)).
 		SetComputeLimit(flowgo.DefaultMaxTransactionGasLimit).
-		AddAuthorizer(b.GetChain().ServiceAddress()).
-		SetPayer(b.GetChain().ServiceAddress()).
+		AddAuthorizer(serviceAddress).
+		SetPayer(serviceAddress).
 		SetReferenceBlockID(b.pendingBlock.parentID)
 
 	return tx, nil

--- a/emulator/templates/systemChunkTransactionTemplate.cdc
+++ b/emulator/templates/systemChunkTransactionTemplate.cdc
@@ -8,11 +8,9 @@ transaction {
             ?? panic("Couldn't borrow RandomBeaconHistory.Heartbeat Resource")
         randomBeaconHistoryHeartbeat.heartbeat(randomSourceHistory: randomSourceHistory())
 
-        let evmHeartbeat = serviceAccount.storage.borrow<&EVM.Heartbeat>(from: /storage/EVMHeartbeat)
-        if evmHeartbeat != nil { // skip if not available
-            evmHeartbeat!.heartbeat()
-        } else {
-            panic("Couldn't borrow EVM.Heartbeat Resource")
-        }
+        let evmHeartbeat = serviceAccount.storage
+            .borrow<&EVM.Heartbeat>(from: /storage/EVMHeartbeat)
+            ?? panic("Couldn't borrow EVM.Heartbeat Resource")
+        evmHeartbeat.heartbeat()
     }
 }

--- a/emulator/templates/systemChunkTransactionTemplate.cdc
+++ b/emulator/templates/systemChunkTransactionTemplate.cdc
@@ -1,4 +1,5 @@
 import RandomBeaconHistory from "RandomBeaconHistory"
+import EVM from "EVM"
 
 transaction {
     prepare(serviceAccount: auth(BorrowValue) &Account) {
@@ -6,5 +7,12 @@ transaction {
             .borrow<&RandomBeaconHistory.Heartbeat>(from: RandomBeaconHistory.HeartbeatStoragePath)
             ?? panic("Couldn't borrow RandomBeaconHistory.Heartbeat Resource")
         randomBeaconHistoryHeartbeat.heartbeat(randomSourceHistory: randomSourceHistory())
+
+        let evmHeartbeat = serviceAccount.storage.borrow<&EVM.Heartbeat>(from: /storage/EVMHeartbeat)
+        if evmHeartbeat != nil { // skip if not available
+            evmHeartbeat!.heartbeat()
+        } else {
+            panic("Couldn't borrow EVM.Heartbeat Resource")
+        }
     }
 }

--- a/server/access/streamBackend.go
+++ b/server/access/streamBackend.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/flow-go/engine/access/state_stream"
 	"github.com/onflow/flow-go/engine/access/state_stream/backend"
 	"github.com/onflow/flow-go/engine/access/subscription"
@@ -200,14 +201,13 @@ func getExecutionDataFunc(blockchain *emulator.Blockchain) GetExecutionDataFunc 
 		// The `EVM.BlockExecuted` event is only emitted from the
 		// system chunk transaction, and we need to make it available
 		// in the returned response.
-		evmBlockExecutedEventType := fmt.Sprintf(
-			"A.%s.%s",
-			blockchain.GetChain().ServiceAddress().Hex(),
-			string(evmTypes.EventTypeBlockExecuted),
-		)
+		evmBlockExecutedEventType := common.AddressLocation{
+			Address: common.Address(blockchain.GetChain().ServiceAddress()),
+			Name:    string(evmTypes.EventTypeBlockExecuted),
+		}
 		events, err := blockchain.GetEventsByHeight(
 			height,
-			evmBlockExecutedEventType,
+			evmBlockExecutedEventType.ID(),
 		)
 		if err != nil {
 			return nil, err

--- a/server/access/streamBackend.go
+++ b/server/access/streamBackend.go
@@ -29,7 +29,7 @@ import (
 	"github.com/onflow/flow-go/engine/access/state_stream/backend"
 	"github.com/onflow/flow-go/engine/access/subscription"
 	"github.com/onflow/flow-go/engine/common/rpc"
-	evmTypes "github.com/onflow/flow-go/fvm/evm/types"
+	evmEvents "github.com/onflow/flow-go/fvm/evm/events"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
 	"github.com/onflow/flow-go/storage"
@@ -203,8 +203,9 @@ func getExecutionDataFunc(blockchain *emulator.Blockchain) GetExecutionDataFunc 
 		// in the returned response.
 		evmBlockExecutedEventType := common.AddressLocation{
 			Address: common.Address(blockchain.GetChain().ServiceAddress()),
-			Name:    string(evmTypes.EventTypeBlockExecuted),
+			Name:    string(evmEvents.EventTypeBlockExecuted),
 		}
+
 		events, err := blockchain.GetEventsByHeight(
 			height,
 			evmBlockExecutedEventType.ID(),

--- a/storage/migration/cadence1_test.go
+++ b/storage/migration/cadence1_test.go
@@ -572,11 +572,15 @@ func TestLoadMigratedValuesInTransaction(t *testing.T) {
 		result.Logs,
 	)
 
-	_, err = blockchain.CommitBlock()
-	require.NoError(t, err)
+	// TEMP: Disable for now, as block commitment requires
+	// the EVM contract to be deployed. The system chunk
+	// transaction is calling the EVM.Heartbeat.heartbeat()
+	// method, to advance the EVM blocks.
+	// _, err = blockchain.CommitBlock()
+	// require.NoError(t, err)
 
 	// tx status becomes TransactionStatusSealed
-	tx1Result, err := adapter.GetTransactionResult(context.Background(), tx.ID())
-	require.NoError(t, err)
-	require.Equal(t, flowsdk.TransactionStatusSealed, tx1Result.Status)
+	// tx1Result, err := adapter.GetTransactionResult(context.Background(), tx.ID())
+	// require.NoError(t, err)
+	// require.Equal(t, flowsdk.TransactionStatusSealed, tx1Result.Status)
 }

--- a/storage/migration/cadence1_test.go
+++ b/storage/migration/cadence1_test.go
@@ -94,7 +94,7 @@ func migrateEmulatorState(t *testing.T, store *sqlite.Store) {
 	err := MigrateCadence1(
 		store,
 		t.TempDir(),
-		migrations.EVMContractChangeNone,
+		migrations.EVMContractChangeDeployMinimalAndUpdateFull,
 		migrations.BurnerContractChangeDeploy,
 		stagedContracts,
 		rwf,
@@ -572,15 +572,11 @@ func TestLoadMigratedValuesInTransaction(t *testing.T) {
 		result.Logs,
 	)
 
-	// TEMP: Disable for now, as block commitment requires
-	// the EVM contract to be deployed. The system chunk
-	// transaction is calling the EVM.Heartbeat.heartbeat()
-	// method, to advance the EVM blocks.
-	// _, err = blockchain.CommitBlock()
-	// require.NoError(t, err)
+	_, err = blockchain.CommitBlock()
+	require.NoError(t, err)
 
 	// tx status becomes TransactionStatusSealed
-	// tx1Result, err := adapter.GetTransactionResult(context.Background(), tx.ID())
-	// require.NoError(t, err)
-	// require.Equal(t, flowsdk.TransactionStatusSealed, tx1Result.Status)
+	tx1Result, err := adapter.GetTransactionResult(context.Background(), tx.ID())
+	require.NoError(t, err)
+	require.Equal(t, flowsdk.TransactionStatusSealed, tx1Result.Status)
 }


### PR DESCRIPTION
Depends on #719
## Description

The emission of `EVM.BlockExecuted` events is now part of the system chunk transaction.
In order for tools using the Flow Emulator, to function properly, we need to handle this in Emulator's system chunk transaction as well.
Furthermore, since this system chunk transaction is rather special, we need to make its event/s available to APIs such as the event streaming.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
