### PR TITLE
Update to Cadence v1.0.0-preview.42

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,11 +14,11 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v1.0.0-preview.41
+	github.com/onflow/cadence v1.0.0-preview.42
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.3.1
-	github.com/onflow/flow-go v0.36.8-0.20240729205403-18c8533fa521
-	github.com/onflow/flow-go-sdk v1.0.0-preview.44
+	github.com/onflow/flow-go v0.37.0-crescendo-RC3.0.20240808013212-1dd0921e5306
+	github.com/onflow/flow-go-sdk v1.0.0-preview.45
 	github.com/onflow/flow-nft/lib/go/contracts v1.2.1
 	github.com/onflow/flow/protobuf/go/flow v0.4.5
 	github.com/prometheus/client_golang v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -2045,8 +2045,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.8.0-rc.5 h1:1sU+c6UfDzq/EjM8nTw4EI8GvEMarcxkWkJKy6piFSY=
 github.com/onflow/atree v0.8.0-rc.5/go.mod h1:yccR+LR7xc1Jdic0mrjocbHvUD7lnVvg8/Ct1AA5zBo=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.41 h1:nEfnCF8IA/+i31twFKOimzbDVUo4tOlaqBtlDaGB4qM=
-github.com/onflow/cadence v1.0.0-preview.41/go.mod h1:BCoenp1TYp+SmG7FGWStjehvvzcvNQ3xvpK5rkthq3Y=
+github.com/onflow/cadence v1.0.0-preview.42 h1:oJYGxKn/oMiJnhwbuviSQRJFAFiNKcEt6YBqNX61Bu4=
+github.com/onflow/cadence v1.0.0-preview.42/go.mod h1:BCoenp1TYp+SmG7FGWStjehvvzcvNQ3xvpK5rkthq3Y=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -2058,11 +2058,11 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0 h1:mToacZ5NWqtlWwk/7RgIl/jeKB/
 github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.36.8-0.20240729205403-18c8533fa521 h1:UZWR6uEfoDrzv0qu2YtSc5dGseFhkN2yf0wnp5F3YXI=
-github.com/onflow/flow-go v0.36.8-0.20240729205403-18c8533fa521/go.mod h1:8ALdV6VGy3JT7IzL5yopjG9n6KG8Mg6zJT1WW8+AY2s=
+github.com/onflow/flow-go v0.37.0-crescendo-RC3.0.20240808013212-1dd0921e5306 h1:/GqewCxVZAq5Ics+YxktxfcuSyAFYORc5wpQRFEAp88=
+github.com/onflow/flow-go v0.37.0-crescendo-RC3.0.20240808013212-1dd0921e5306/go.mod h1:8sBs4NhPdbkUXkO/+DtWyCG08FZWBz1PJyeX1TRFSpE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.44 h1:KgO5OedGS94UPDRpnvPH4bEfNKt4VI8BP16rY+LCuQE=
-github.com/onflow/flow-go-sdk v1.0.0-preview.44/go.mod h1:TWKQyGN2rrTlMem1g8ATOHOKJfjjzLUwjJsoe7vLfxY=
+github.com/onflow/flow-go-sdk v1.0.0-preview.45 h1:cbxKT2Z1umA4Vib0t28xHiFrygZyyjBqIcYGaeE9dzg=
+github.com/onflow/flow-go-sdk v1.0.0-preview.45/go.mod h1:26E0SDbNHkxtBnxOatQi3tpAh8tehsV8gt/8IH2nyww=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1 h1:woAAS5z651sDpi7ihAHll8NvRS9uFXIXkL6xR+bKFZY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.0.0-preview.42](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.42)
- [onflow/flow-go-sdk v1.0.0-preview.45](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.45)
- [onflow/flow-go 1dd0921e530648dc42041db628ef84aaa8dbb175](https://github.com/onflow/flow-go/commit/1dd0921e530648dc42041db628ef84aaa8dbb175)

