### PR TITLE
Update to Cadence v1.0.0-preview.51

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,11 +14,11 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v1.0.0-preview.50
+	github.com/onflow/cadence v1.0.0-preview.51
 	github.com/onflow/crypto v0.25.2
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.3.1
-	github.com/onflow/flow-go v0.37.7-0.20240829173042-9708618afd98
-	github.com/onflow/flow-go-sdk v1.0.0-preview.53
+	github.com/onflow/flow-go v0.37.7-0.20240830182756-9ac9e1889c34
+	github.com/onflow/flow-go-sdk v1.0.0-preview.54
 	github.com/onflow/flow-nft/lib/go/contracts v1.2.1
 	github.com/onflow/flow/protobuf/go/flow v0.4.6
 	github.com/prometheus/client_golang v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -2046,8 +2046,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.8.0-rc.6 h1:GWgaylK24b5ta2Hq+TvyOF7X5tZLiLzMMn7lEt59fsA=
 github.com/onflow/atree v0.8.0-rc.6/go.mod h1:yccR+LR7xc1Jdic0mrjocbHvUD7lnVvg8/Ct1AA5zBo=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.50 h1:sEfUOG7BXzEqPzB68yZZrG/lkBmHf/o0poYDCY18x3A=
-github.com/onflow/cadence v1.0.0-preview.50/go.mod h1:7wvvecnAZtYOspLOS3Lh+FuAmMeSrXhAWiycC3kQ1UU=
+github.com/onflow/cadence v1.0.0-preview.51 h1:L+toCS2Sw9bsExc2PxeNMmAK96fn2LdTOD9bl5K/etA=
+github.com/onflow/cadence v1.0.0-preview.51/go.mod h1:7wvvecnAZtYOspLOS3Lh+FuAmMeSrXhAWiycC3kQ1UU=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.2 h1:GjHunqVt+vPcdqhxxhAXiMIF3YiLX7gTuTR5O+VG2ns=
 github.com/onflow/crypto v0.25.2/go.mod h1:fY7eLqUdMKV8EGOw301unP8h7PvLVy8/6gVR++/g0BY=
@@ -2059,11 +2059,11 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0 h1:mToacZ5NWqtlWwk/7RgIl/jeKB/
 github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.37.7-0.20240829173042-9708618afd98 h1:IPTibfA1CnWLN2Ct3woHVEh+7A+ff4PG4OPYJd+pN08=
-github.com/onflow/flow-go v0.37.7-0.20240829173042-9708618afd98/go.mod h1:7ZwLTHAdY/T9ulmcgprxyiNxweQwAnBmp+jq2LyJ654=
+github.com/onflow/flow-go v0.37.7-0.20240830182756-9ac9e1889c34 h1:5yHX09MtQxNvt2wT5KV1fz+1/iWvBl2IkDr5svGiFN0=
+github.com/onflow/flow-go v0.37.7-0.20240830182756-9ac9e1889c34/go.mod h1:HFx3KzQeT+u3SoCGaD5zXyK7VF7SRI61P0aO2SDjaro=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.53 h1:hF6X5b9gVQoc/wUa5JTcYU6tw1B7aW71XDdfsFhU5Gw=
-github.com/onflow/flow-go-sdk v1.0.0-preview.53/go.mod h1:FtsoOHw5RNmMMwC7jI1hc99ZVJWhnm/gE3OMvFaZjyg=
+github.com/onflow/flow-go-sdk v1.0.0-preview.54 h1:5GjCkyIyvE9KolOUUPTkGdEiV/8qOe1MGnLHOLBmthA=
+github.com/onflow/flow-go-sdk v1.0.0-preview.54/go.mod h1:u9oFiS25TpnU1EW62PQlq22jzkwBAj4VEiiCBM6nhHo=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1 h1:woAAS5z651sDpi7ihAHll8NvRS9uFXIXkL6xR+bKFZY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.0.0-preview.51](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.51)
- [onflow/flow-go-sdk v1.0.0-preview.54](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.54)
- [onflow/flow-go 9ac9e1889c34](https://github.com/onflow/flow-go/commit/9ac9e1889c34)

