### PR TITLE
fix: fix slice init length

### DIFF
--- a/server/debugger/debugsession.go
+++ b/server/debugger/debugsession.go
@@ -649,7 +649,7 @@ func (s *session) convertStorageMapToDAPVariables(
 	value *interpreter.StorageMap,
 ) []dap.Variable {
 
-	members := make([]dap.Variable, value.Count())
+	members := make([]dap.Variable, 0, value.Count())
 
 	it := value.Iterator(inter)
 	for {


### PR DESCRIPTION


## Description

The intention here should be to initialize a slice with a capacity of   `value.Count()`  rather than initializing the length of this slice.

The online demo: https://go.dev/play/p/q1BcVCmvidW


______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
