### PR TITLE
refactor: replace golang.org/x/exp with stdlib

### DIFF
--- a/server/utils/emulator.go
+++ b/server/utils/emulator.go
@@ -21,12 +21,11 @@ package utils
 import (
 	"encoding/json"
 	"net/http"
+	"slices"
 	"strconv"
 
 	"github.com/gorilla/mux"
 	flowgo "github.com/onflow/flow-go/model/flow"
-	"golang.org/x/exp/slices"
-
 	"github.com/onflow/flow-emulator/adapters"
 	"github.com/onflow/flow-emulator/emulator"
 )


### PR DESCRIPTION
Closes #???

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Since Go 1.21, the functions in x/exp used here can already be replaced by functions from the standard library

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
