### PR TITLE
Added optional middleware param to emulator start for metrics

### DIFF
--- a/cmd/emulator/main.go
+++ b/cmd/emulator/main.go
@@ -43,7 +43,12 @@ func defaultServiceKey(
 }
 
 func main() {
-	if err := start.Cmd(defaultServiceKey).Execute(); err != nil {
+	config := start.StartConfig{
+		GetServiceKey:   defaultServiceKey,
+		RestMiddlewares: []start.HttpMiddleware{},
+	}
+
+	if err := start.Cmd(config).Execute(); err != nil {
 		start.Exit(1, err.Error())
 	}
 }

--- a/server/access/rest.go
+++ b/server/access/rest.go
@@ -82,6 +82,12 @@ func (r *RestServer) Stop() {
 	_ = r.server.Shutdown(context.Background())
 }
 
+func (r *RestServer) UseMiddleware(middleware func(http.Handler) http.Handler) {
+	if r.server != nil {
+		r.server.Handler = middleware(r.server.Handler)
+	}
+}
+
 func NewRestServer(logger *zerolog.Logger, blockchain *emulator.Blockchain, adapter *adapters.AccessAdapter, chain flow.Chain, host string, port int, debug bool) (*RestServer, error) {
 
 	debugLogger := zerolog.Logger{}

--- a/server/server.go
+++ b/server/server.go
@@ -20,6 +20,7 @@ package server
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"sort"
 	"time"
@@ -510,4 +511,10 @@ func sanitizeConfig(conf *Config) *Config {
 	}
 
 	return conf
+}
+
+func (s *EmulatorServer) UseRestMiddleware(middleware func(http.Handler) http.Handler) {
+	if s.rest != nil {
+		s.rest.UseMiddleware(middleware)
+	}
 }


### PR DESCRIPTION
Closes #812.

## Description

Added an optional http middleware parameter that can be added to rest api server. The goal is being able to use analytics to get some developers metrics as per https://github.com/onflow/flow-cli/issues/1919.
