### PR TITLE
Fixed docker image not building

### DIFF
--- a/cmd/emulator/Dockerfile
+++ b/cmd/emulator/Dockerfile
@@ -3,7 +3,7 @@
 # NOTE: Must be run in the context of the repo's root directory
 
 ## Build the app binary
-FROM --platform=$BUILDPLATFORM golang:1.22 AS build-app
+FROM --platform=$BUILDPLATFORM golang:1.23 AS build-app
 
 # Build the app binary in /app
 RUN mkdir /app


### PR DESCRIPTION
Closes #816.

## Description

Updated go version in dockerfile to allow docker image building.
