### PR TITLE
Respect config values for EVM VM bridge setup

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -446,6 +446,7 @@ func configureBlockchain(logger *zerolog.Logger, conf *Config, store storage.Sto
 		emulator.WithTransactionFeesEnabled(conf.TransactionFeesEnabled),
 		emulator.WithChainID(conf.ChainID),
 		emulator.WithContractRemovalEnabled(conf.ContractRemovalEnabled),
+		emulator.WithSetupVMBridgeEnabled(conf.SetupVMBridgeEnabled),
 	}
 
 	if conf.SkipTransactionValidation {
@@ -492,13 +493,6 @@ func configureBlockchain(logger *zerolog.Logger, conf *Config, store storage.Sto
 		options = append(
 			options,
 			emulator.WithSetupEVMEnabled(true),
-		)
-	}
-
-	if conf.SetupVMBridgeEnabled {
-		options = append(
-			options,
-			emulator.WithSetupVMBridgeEnabled(true),
 		)
 	}
 


### PR DESCRIPTION
## Description

The default values for `SetupEVMEnabled` & `SetupVMBridgeEnabled` are `true`.
However, if for whatever reason, someone tries to set `false` for these two, it isn't possible to do so.
Because the option is only appended when `conf.SetupEVMEnabled` & `conf.SetupVMBridgeEnabled` are set to `true`.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
