### PR TITLE
Avoided skipping execution on empty blocks to allow scheduled callbacks to be run

### DIFF
--- a/emulator/blockchain.go
+++ b/emulator/blockchain.go
@@ -1262,7 +1262,7 @@ func (b *Blockchain) executeBlock() ([]*types.TransactionResult, error) {
 	blockContext := b.setFVMContextFromHeader(header)
 
 	// cannot execute a block that has already executed (only relevant for non-empty blocks)
-	if !b.pendingBlock.Empty() && b.pendingBlock.ExecutionComplete() {
+	if b.pendingBlock.ExecutionComplete() && !b.pendingBlock.Empty() {
 		return results, &types.PendingBlockTransactionsExhaustedError{
 			BlockID: b.pendingBlock.ID(),
 		}


### PR DESCRIPTION
## Description

Removing skipping blocks execution so that scheduled callbacks can be run automatically on each block using the --block-time flag
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
