### PR TITLE
Update CODEOWNERS to remove '@bluesign'

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @janezpodhostnik @bluesign @chasefleming @jribbink @peterargue @mfbz
+* @janezpodhostnik @chasefleming @jribbink @peterargue @mfbz


### PR DESCRIPTION
Closes #???

## Description

Removing myself from CODEOWNERS as I don't have much contributions lately and planning to focus on other projects.

NOTE: also need to assign default issue template to someone, if any volunteers.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the GitHub PR explorer
- [ ] Added appropriate labels
