### PR TITLE
Automatically commit reference block after fork mode initialization

### DIFF
--- a/server/fork_integration_test.go
+++ b/server/fork_integration_test.go
@@ -69,11 +69,6 @@ func TestForkingAgainstTestnet(t *testing.T) {
 		t.Fatalf("expected ChainID to be Testnet after fork detection, got %q", cfg.ChainID)
 	}
 
-	// Create an initial local block so we have a valid reference block ID in the forked store
-	if _, _, err := srv.Emulator().ExecuteAndCommitBlock(); err != nil {
-		t.Fatalf("prime local block: %v", err)
-	}
-
 	// Submit a minimal transaction against the forked emulator to ensure tx processing works
 	latest, err := srv.Emulator().GetLatestBlock()
 	if err != nil {
@@ -203,11 +198,6 @@ func TestForkingAgainstMainnet(t *testing.T) {
 
 	if cfg.ChainID != flowgo.Mainnet {
 		t.Fatalf("expected ChainID to be Mainnet after fork detection, got %q", cfg.ChainID)
-	}
-
-	// Create an initial local block so we have a valid reference block ID in the forked store
-	if _, _, err := srv.Emulator().ExecuteAndCommitBlock(); err != nil {
-		t.Fatalf("prime local block: %v", err)
 	}
 
 	// Test account key retrieval for a known mainnet account with multiple keys

--- a/server/server.go
+++ b/server/server.go
@@ -193,6 +193,19 @@ func NewEmulatorServer(logger *zerolog.Logger, conf *Config) *EmulatorServer {
 		return nil
 	}
 
+	// In fork mode, commit an initial reference block so transactions can be submitted immediately
+	if conf.ForkHost != "" {
+		block, _, err := emulatedBlockchain.ExecuteAndCommitBlock()
+		if err != nil {
+			logger.Error().Err(err).Msg("❗  Failed to commit initial reference block for fork mode")
+			return nil
+		}
+		logger.Info().
+			Uint64("blockHeight", block.Height).
+			Str("blockID", block.ID().String()).
+			Msg("📦 Committed initial reference block for fork mode")
+	}
+
 	chain := emulatedBlockchain.GetChain()
 
 	sc := systemcontracts.SystemContractsForChain(chain.ChainID())


### PR DESCRIPTION
Closes #899

## Description

When fork mode is initialized, the emulator now automatically commits an initial empty block to provide a valid reference block ID for transactions. This eliminates the need for users to manually call ExecuteAndCommitBlock() before submitting transactions.

Previously, fork mode would initialize but leave the emulator in a state where it couldn't accept transactions until a reference block was manually committed. Tests had to work around this by explicitly committing a block.

Changes:
- Auto-commit initial reference block in NewEmulatorServer when ForkHost is set
- Remove manual workaround from fork integration tests
- Add logging for the committed reference block

Fixes the issue where forked emulators were not immediately ready to accept transactions.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
