### PR TITLE
Add endpoint to download ZIP file of all contracts

### DIFF
--- a/server/utils/emulator.go
+++ b/server/utils/emulator.go
@@ -332,8 +332,6 @@ func (m EmulatorAPIServer) Logs(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-const cadenceFileSuffix = ".cdc"
-
 func (m EmulatorAPIServer) AllContractsZip(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", "attachment; filename=contracts.zip")
 	w.Header().Set("Content-Type", "application/zip")


### PR DESCRIPTION
## Description

Add a new endpoint `/emulator/all-contracts` which downloads a ZIP file of all deployed contracts.

This is useful for viewing the computation profile.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to GitHub issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-emulator/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the GitHub PR explorer
- [x] Added appropriate labels
