### PR TITLE
Update to latest flow-go `master` version

### DIFF
--- a/emulator/blockchain.go
+++ b/emulator/blockchain.go
@@ -680,7 +680,6 @@ func configureFVM(blockchain *Blockchain, conf config, blocks *blocks) (*fvm.Vir
 		fvm.WithTransactionFeesEnabled(conf.TransactionFeesEnabled),
 		fvm.WithReusableCadenceRuntimePool(customRuntimePool),
 		fvm.WithEntropyProvider(blockchain.entropyProvider),
-		fvm.WithEVMEnabled(true),
 	}
 
 	if !conf.TransactionValidationEnabled {

--- a/go.mod
+++ b/go.mod
@@ -12,11 +12,11 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/improbable-eng/grpc-web v0.15.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v1.9.2
+	github.com/onflow/cadence v1.9.3
 	github.com/onflow/crypto v0.25.3
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.9.2
-	github.com/onflow/flow-go v0.44.17
-	github.com/onflow/flow-go-sdk v1.9.8
+	github.com/onflow/flow-go v0.45.0-experimental-cadence-v1.8.7.0.20260107152219-757836bbe8dc
+	github.com/onflow/flow-go-sdk v1.9.9
 	github.com/onflow/flow-nft/lib/go/contracts v1.3.0
 	github.com/onflow/flow/protobuf/go/flow v0.4.18
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -752,8 +752,8 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onflow/atree v0.12.0 h1:X7/UEPyCaaEQ1gCg11KDvfyEtEeQLhtRtxMHjAiH/Co=
 github.com/onflow/atree v0.12.0/go.mod h1:qdZcfLQwPirHcNpLiK+2t3KAo+SAb9Si6TqurE6pykE=
-github.com/onflow/cadence v1.9.2 h1:r1hKhbrFJgrLCHj8N0Bp8/gfG9Vc5WTYOtDjdcWqEk4=
-github.com/onflow/cadence v1.9.2/go.mod h1:MlJsCwhCZwdnAUd24XHzcsizZfG7a2leab1PztabUsE=
+github.com/onflow/cadence v1.9.3 h1:oUwGSdstzV6W/CfdjTuhdCWmXab0M/LNvrtpW7uF7J8=
+github.com/onflow/cadence v1.9.3/go.mod h1:MlJsCwhCZwdnAUd24XHzcsizZfG7a2leab1PztabUsE=
 github.com/onflow/crypto v0.25.3 h1:XQ3HtLsw8h1+pBN+NQ1JYM9mS2mVXTyg55OldaAIF7U=
 github.com/onflow/crypto v0.25.3/go.mod h1:+1igaXiK6Tjm9wQOBD1EGwW7bYWMUGKtwKJ/2QL/OWs=
 github.com/onflow/fixed-point v0.1.1 h1:j0jYZVO8VGyk1476alGudEg7XqCkeTVxb5ElRJRKS90=
@@ -768,10 +768,10 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.1 h1:Ts5ob+CoCY2EjEd0W6vdLJ7hLL3
 github.com/onflow/flow-ft/lib/go/contracts v1.0.1/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1 h1:FDYKAiGowABtoMNusLuRCILIZDtVqJ/5tYI4VkF5zfM=
 github.com/onflow/flow-ft/lib/go/templates v1.0.1/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.44.17 h1:4Ar+YmWfMbXIg5MJe88j0dRHcbE8+KLp3mRwIOQoP2U=
-github.com/onflow/flow-go v0.44.17/go.mod h1:bp3gC9VTf4Hcck1PuI9Jc9AsGddom2GmCcOdwOSOOS8=
-github.com/onflow/flow-go-sdk v1.9.8 h1:Bh3TQSXjsZqKqg26WB5PXBipqJjU/zLem3L7IIWktNQ=
-github.com/onflow/flow-go-sdk v1.9.8/go.mod h1:KWKBqUZDwLSgv8ID0AZ3SAvP4kNFZLnCvdkJRw7Xqro=
+github.com/onflow/flow-go v0.45.0-experimental-cadence-v1.8.7.0.20260107152219-757836bbe8dc h1:8LcSRNnU9HOJp1yqiF3VZ+VV5qOkrSy2W/0ZRP6EfmQ=
+github.com/onflow/flow-go v0.45.0-experimental-cadence-v1.8.7.0.20260107152219-757836bbe8dc/go.mod h1:puXQVqEx+1chcrEIeVBLABfliCrl1iT65glVweS6pJ4=
+github.com/onflow/flow-go-sdk v1.9.9 h1:DLDmlyXmxyLZkipY9N8LRei+5assjUU7AsaJ7gptiYQ=
+github.com/onflow/flow-go-sdk v1.9.9/go.mod h1:SF3dQF1zNFY4kFn24CywrmalhcDvAMm7b3UeDipXyNU=
 github.com/onflow/flow-nft/lib/go/contracts v1.3.0 h1:DmNop+O0EMyicZvhgdWboFG57xz5t9Qp81FKlfKyqJc=
 github.com/onflow/flow-nft/lib/go/contracts v1.3.0/go.mod h1:eZ9VMMNfCq0ho6kV25xJn1kXeCfxnkhj3MwF3ed08gY=
 github.com/onflow/flow-nft/lib/go/templates v1.3.0 h1:uGIBy4GEY6Z9hKP7sm5nA5kwvbvLWW4nWx5NN9Wg0II=
@@ -1531,8 +1531,8 @@ google.golang.org/genproto v0.0.0-20250603155806-513f23925822 h1:rHWScKit0gvAPuO
 google.golang.org/genproto v0.0.0-20250603155806-513f23925822/go.mod h1:HubltRL7rMh0LfnQPkMH4NPDFEWp0jw3vixw7jEM53s=
 google.golang.org/genproto/googleapis/api v0.0.0-20251022142026-3a174f9686a8 h1:mepRgnBZa07I4TRuomDE4sTIYieg/osKmzIf4USdWS4=
 google.golang.org/genproto/googleapis/api v0.0.0-20251022142026-3a174f9686a8/go.mod h1:fDMmzKV90WSg1NbozdqrE64fkuTv6mlq2zxo9ad+3yo=
-google.golang.org/genproto/googleapis/bytestream v0.0.0-20250804133106-a7a43d27e69b h1:YzmLjVBzUKrr0zPM1KkGPEicd3WHSccw1k9RivnvngU=
-google.golang.org/genproto/googleapis/bytestream v0.0.0-20250804133106-a7a43d27e69b/go.mod h1:h6yxum/C2qRb4txaZRLDHK8RyS0H/o2oEDeKY4onY/Y=
+google.golang.org/genproto/googleapis/bytestream v0.0.0-20251124214823-79d6a2a48846 h1:7FlucM2tFADtEDnIlDrR12KdRqV48B1GSTU1U6uKSiY=
+google.golang.org/genproto/googleapis/bytestream v0.0.0-20251124214823-79d6a2a48846/go.mod h1:G3Q0qS3k/oFEmVMddPsSYcFnm2+Mq2XRmxujrtu5hr0=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251124214823-79d6a2a48846 h1:Wgl1rcDNThT+Zn47YyCXOXyX/COgMTIdhJ717F0l4xk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251124214823-79d6a2a48846/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=

--- a/server/access/rest.go
+++ b/server/access/rest.go
@@ -101,7 +101,7 @@ func NewRestServer(logger *zerolog.Logger, blockchain *emulator.Blockchain, adap
 	// only collect metrics if not test
 	if flag.Lookup("test.v") == nil {
 		var err error
-		restCollector, err = metrics.NewRestCollector(router.URLToRoute, prometheus.DefaultRegisterer)
+		restCollector, err = metrics.NewRestCollector(router.MethodURLToRoute, prometheus.DefaultRegisterer)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Description

Update dependencies:

 - flow-go@master
 - cadence@v1.9.3
 - flow-go-sdk@v1.9.9


Still technically blocked until the EVM contract has been updated (otherwise we will have cascading test suite failures for the "fork testing" feature when doing our dep updates), but just staging the updates now so they are ready.