### PR TITLE
fix: eliminate data races in Debugger and ServiceKey

### DIFF
--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -65,6 +65,7 @@ func GenerateDefaultServiceKey(
 
 	return ServiceKey{
 		PrivateKey: privateKey,
+		PublicKey:  privateKey.PublicKey(),
 		SigAlgo:    sigAlgo,
 		HashAlgo:   hashAlgo,
 	}
@@ -75,19 +76,9 @@ func (s ServiceKey) Signer() (sdkcrypto.Signer, error) {
 }
 
 func (s ServiceKey) AccountKey() *flowsdk.AccountKey {
-
-	var publicKey sdkcrypto.PublicKey
-	if s.PublicKey != nil {
-		publicKey = s.PublicKey
-	}
-
-	if s.PrivateKey != nil {
-		publicKey = s.PrivateKey.PublicKey()
-	}
-
 	return &flowsdk.AccountKey{
 		Index:          s.Index,
-		PublicKey:      publicKey,
+		PublicKey:      s.PublicKey,
 		SigAlgo:        s.SigAlgo,
 		HashAlgo:       s.HashAlgo,
 		Weight:         s.Weight,

--- a/server/debugger/debugger.go
+++ b/server/debugger/debugger.go
@@ -35,7 +35,9 @@ type Debugger struct {
 	logger      *zerolog.Logger
 	emulator    emulator.Emulator
 	port        int
+	mu          sync.Mutex // protects listener and stopped
 	listener    net.Listener
+	stopped     bool
 	quit        chan interface{}
 	wg          sync.WaitGroup
 	stopOnce    sync.Once
@@ -58,7 +60,15 @@ func (d *Debugger) Start() (err error) {
 	if err != nil {
 		return err
 	}
+	d.mu.Lock()
 	d.listener = listener
+	alreadyStopped := d.stopped
+	d.mu.Unlock()
+
+	if alreadyStopped {
+		return listener.Close()
+	}
+
 	defer func() {
 		err = listener.Close()
 	}()
@@ -127,8 +137,12 @@ func (d *Debugger) handleConnection(conn net.Conn) {
 func (d *Debugger) Stop() {
 	d.stopOnce.Do(func() {
 		close(d.quit)
-		if d.listener != nil {
-			_ = d.listener.Close()
+		d.mu.Lock()
+		l := d.listener
+		d.stopped = true
+		d.mu.Unlock()
+		if l != nil {
+			_ = l.Close()
 		}
 		for _, conn := range d.connections {
 			_ = conn.Close()


### PR DESCRIPTION
`Debugger.listener` was written in `Start()` and read in `Stop()` concurrently with no synchronization. Added a mutex to guard all accesses and a `stopped` flag so if `Stop()` runs before `Start()` sets the listener, `Start()` detects it and closes the listener immediately instead of starting the serve loop.

`defaultConfig` is a package-level variable whose `ServiceKey.PrivateKey` is a shared pointer across all tests. The `onflow/crypto` library lazily initializes the public key inside the private key struct without synchronization, causing a race when parallel tests both trigger `PublicKey()`. Fixed by eagerly initializing and storing the public key at key-generation time, removing the lazy path entirely.