### PR TITLE
bump flow-core-contracts to v1.10.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/onflow/cadence v1.10.3
 	github.com/onflow/crypto v0.25.4
-	github.com/onflow/flow-core-contracts/lib/go/templates v1.10.2
+	github.com/onflow/flow-core-contracts/lib/go/templates v1.10.3
 	github.com/onflow/flow-go v0.48.1-evm-cache-block.0.20260518173711-5b9fa9c8352e
 	github.com/onflow/flow-go-sdk v1.10.3
 	github.com/onflow/flow-nft/lib/go/contracts v1.4.1
@@ -148,7 +148,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/onflow/atree v0.16.0 // indirect
 	github.com/onflow/fixed-point v0.1.1 // indirect
-	github.com/onflow/flow-core-contracts/lib/go/contracts v1.10.2 // indirect
+	github.com/onflow/flow-core-contracts/lib/go/contracts v1.10.3 // indirect
 	github.com/onflow/flow-evm-bridge v0.2.1 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v1.1.1 // indirect
 	github.com/onflow/flow-ft/lib/go/templates v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -760,8 +760,12 @@ github.com/onflow/fixed-point v0.1.1 h1:j0jYZVO8VGyk1476alGudEg7XqCkeTVxb5ElRJRK
 github.com/onflow/fixed-point v0.1.1/go.mod h1:gJdoHqKtToKdOZbvryJvDZfcpzC7d2fyWuo3ZmLtcGY=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.10.2 h1:OQr7LyoAzk9kVfVjPcHXoFtWIBSqbB7ksNb6wIJlFE8=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.10.2/go.mod h1:fn0eOOINlOdQSOWptENC92MpPorB7dHzZaC3VTAmiQY=
+github.com/onflow/flow-core-contracts/lib/go/contracts v1.10.3 h1:OTJo6PzE8F0EtvBsBvXKVqSA8eCm1uzN+aWwV5gtjPs=
+github.com/onflow/flow-core-contracts/lib/go/contracts v1.10.3/go.mod h1:fn0eOOINlOdQSOWptENC92MpPorB7dHzZaC3VTAmiQY=
 github.com/onflow/flow-core-contracts/lib/go/templates v1.10.2 h1:qq16IwoT+xAh45GfmC9lR+gFCixJWx9NxKgkkP/W4Nw=
 github.com/onflow/flow-core-contracts/lib/go/templates v1.10.2/go.mod h1:bXe+VkZmvM3QYGjfizprStRfasLA/7ii7l6+LHP5V1U=
+github.com/onflow/flow-core-contracts/lib/go/templates v1.10.3 h1:MA0tiuQo69AhaMh8TgEMyJwuKKO3UK8PB8W+Fg1YVt4=
+github.com/onflow/flow-core-contracts/lib/go/templates v1.10.3/go.mod h1:bXe+VkZmvM3QYGjfizprStRfasLA/7ii7l6+LHP5V1U=
 github.com/onflow/flow-evm-bridge v0.2.1 h1:S32kk+UV7/COdQZakIMsJw6vxShel0s8lI3FyGFl9jM=
 github.com/onflow/flow-evm-bridge v0.2.1/go.mod h1:ExhTZax2F+boo13dzT/uAI7rvwewAoz9v+dEXhhFjYg=
 github.com/onflow/flow-ft/lib/go/contracts v1.1.1 h1:BNbP3CrTIgScpx2NS9snq9XDESFjgXrMXTrwk5H4iSs=


### PR DESCRIPTION
## Summary
- Bumps `github.com/onflow/flow-core-contracts/lib/go/contracts` and `lib/go/templates` from `v1.10.2` to `v1.10.3`

## What is in v1.10.3
- Port internal fixes by @SupunS
- Fix wildcard import by @turbolent

## Test plan
- [ ] CI passes

Generated with Claude Code